### PR TITLE
Implement navigation structure using Navigation3

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/MainActivity.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/MainActivity.kt
@@ -4,13 +4,11 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.amrubio27.cursotestingandroid.core.presentation.navigation.NavGraph
 import com.amrubio27.cursotestingandroid.ui.theme.CursoTestingAndroidTheme
 
 class MainActivity : ComponentActivity() {
@@ -19,12 +17,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             CursoTestingAndroidTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                NavGraph()
             }
         }
     }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/navigation/NavGraph.kt
@@ -1,0 +1,37 @@
+package com.amrubio27.cursotestingandroid.core.presentation.navigation
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavGraph
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+
+@Composable
+fun NavGraph() {
+    val backStack: NavBackStack<NavKey> = rememberNavBackStack(Screen.ProductList)
+    val entries: (NavKey) -> NavEntry<NavKey> = entryProvider<NavKey> {
+        entry<Screen.ProductList> {
+            Text("ProductList", fontSize = 30.sp)
+        }
+        entry<Screen.Cart> {
+            Text("Cart", fontSize = 30.sp)
+        }
+        entry<Screen.Setting> {
+            Text("Setting", fontSize = 30.sp)
+        }
+        entry<Screen.ProductDetail> {
+            Text("ProductDetail", fontSize = 30.sp)
+        }
+    }
+    NavDisplay(
+        backStack = backStack,
+        entryProvider = entries,
+        onBack = { backStack.removeLastOrNull() }
+    )
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/navigation/Screen.kt
@@ -1,0 +1,19 @@
+package com.amrubio27.cursotestingandroid.core.presentation.navigation
+
+import androidx.navigation3.runtime.NavKey
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface Screen: NavKey {
+    @Serializable
+    data object ProductList: Screen
+
+    @Serializable
+    data object Cart : Screen
+
+    @Serializable
+    data object Setting : Screen
+
+    @Serializable
+    data class ProductDetail(val productId: String): Screen
+}


### PR DESCRIPTION

This pull request introduces a navigation architecture to the app by adding a new navigation graph and screen definitions, and updates the main activity to use this navigation system. The changes lay the foundation for navigating between different screens such as product list, cart, settings, and product detail.

Navigation architecture setup:

* Added a new `NavGraph` composable that manages navigation between screens using the `navigation3` library, displaying placeholder text for each screen. (`app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/navigation/NavGraph.kt`)
* Created a sealed interface `Screen` implementing `NavKey`, defining navigation destinations: `ProductList`, `Cart`, `Setting`, and `ProductDetail` (with a `productId` argument). (`app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/navigation/Screen.kt`)

Integration into main activity:

* Updated `MainActivity` to use the new `NavGraph` composable instead of the previous static `Greeting` UI, and removed unused imports and code related to the old layout. (`app/src/main/java/com/amrubio27/cursotestingandroid/MainActivity.kt`) [[1]](diffhunk://#diff-ce9a13796893f75718530fa018a28712c210e47e37e816870cb93e7433c9eb19L7-R11) [[2]](diffhunk://#diff-ce9a13796893f75718530fa018a28712c210e47e37e816870cb93e7433c9eb19L22-R20)