### PR TITLE
Core/3/didaggerhilt

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/MainActivity.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/MainActivity.kt
@@ -10,7 +10,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.amrubio27.cursotestingandroid.core.presentation.navigation.NavGraph
 import com.amrubio27.cursotestingandroid.ui.theme.CursoTestingAndroidTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/MarketApp.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/MarketApp.kt
@@ -1,0 +1,7 @@
+package com.amrubio27.cursotestingandroid
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class MarketApp : Application() {}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreen.kt
@@ -1,0 +1,13 @@
+package com.amrubio27.cursotestingandroid.productlist.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+
+@Composable
+fun ProductListScreen(
+    modifier: Modifier = Modifier,
+    productListViewModel: ProductListViewModel = hiltViewModel()
+) {
+
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListViewModel.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListViewModel.kt
@@ -1,0 +1,10 @@
+package com.amrubio27.cursotestingandroid.productlist.presentation
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jakarta.inject.Inject
+
+@HiltViewModel
+class ProductListViewModel @Inject constructor() : ViewModel() {
+
+}


### PR DESCRIPTION
This pull request introduces the initial setup for integrating Hilt dependency injection into the project, along with scaffolding for the product list feature. The most important changes include configuring the application and activity classes for Hilt, and adding placeholder classes for the product list screen and its ViewModel.

**Dependency Injection Setup:**

* Added a new `MarketApp` class annotated with `@HiltAndroidApp` to serve as the application entry point for Hilt.
* Annotated `MainActivity` with `@AndroidEntryPoint` to enable field injection with Hilt in the activity.

**Product List Feature Scaffolding:**

* Created a `ProductListViewModel` class annotated with `@HiltViewModel` and set up constructor injection, preparing it for dependency injection.
* Added a `ProductListScreen` composable that obtains its ViewModel instance using Hilt's `hiltViewModel()` function.