### PR TITLE
Set up Product List state management and UI structure

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
+        android:name=".MarketApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListEvent.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListEvent.kt
@@ -1,0 +1,5 @@
+package com.amrubio27.cursotestingandroid.productlist.presentation
+
+sealed interface ProductListEvent {
+    data class ShowMessage(val message: String) : ProductListEvent
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreen.kt
@@ -1,13 +1,84 @@
 package com.amrubio27.cursotestingandroid.productlist.presentation
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 @Composable
 fun ProductListScreen(
     modifier: Modifier = Modifier,
     productListViewModel: ProductListViewModel = hiltViewModel()
 ) {
+    val uiState by productListViewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
 
+
+    LaunchedEffect(Unit) {
+        productListViewModel.events.collect { event ->
+            when (event) {
+                is ProductListEvent.ShowMessage -> {
+                    snackbarHostState.showSnackbar(event.message)
+                }
+            }
+        }
+    }
+
+    Scaffold(
+        modifier = modifier,
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { paddingValues ->
+        when (val state = uiState) {
+            ProductListUiState.Loading -> {
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            is ProductListUiState.Error -> {
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        "ERROR",
+                        fontSize = 30.sp,
+                        color = Color.Red
+                    )
+                }
+            }
+
+            is ProductListUiState.Success -> {
+                Column(
+                    Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues)
+                ) {
+                    //state.sealed...
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListUiState.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListUiState.kt
@@ -1,0 +1,13 @@
+package com.amrubio27.cursotestingandroid.productlist.presentation
+
+sealed class ProductListUiState {
+    data object Loading : ProductListUiState()
+    data class Error(val message: String) : ProductListUiState()
+    data class Success(
+        //val products: List<>,
+        //val categories:List<>.
+        val selectedCategory: String,
+        //sortOption
+    ) : ProductListUiState()
+
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListViewModel.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListViewModel.kt
@@ -3,8 +3,28 @@ package com.amrubio27.cursotestingandroid.productlist.presentation
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jakarta.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 @HiltViewModel
 class ProductListViewModel @Inject constructor() : ViewModel() {
+    private val _uiState = MutableStateFlow<ProductListUiState>(ProductListUiState.Loading)
+    val uiState: StateFlow<ProductListUiState> = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<ProductListEvent>(extraBufferCapacity = 1)
+    val events: SharedFlow<ProductListEvent> = _events
+
+    init {
+        loadProducts()
+    }
+
+    fun loadProducts() {
+        _uiState.value = ProductListUiState.Loading
+    }
+
+
 
 }


### PR DESCRIPTION
This pull request introduces the foundation for a new product list screen using Jetpack Compose, structured UI state management, and event-driven messaging. The changes establish a scalable architecture for handling UI states and user feedback, preparing the codebase for further development of the product list feature.

**UI State Management and Event Handling:**

* Introduced a sealed class `ProductListUiState` to represent the loading, error, and success states of the product list UI, enabling structured and type-safe state handling.
* Created a sealed interface `ProductListEvent` for UI events such as displaying messages, supporting an event-driven approach to user notifications.
* Updated `ProductListViewModel` to use `StateFlow` for UI state and `SharedFlow` for events, initializing the state as loading and providing a `loadProducts` function to trigger state changes.

**UI Implementation with Jetpack Compose:**

* Developed the `ProductListScreen` composable to observe the UI state and events from the ViewModel, display loading and error states, and show snackbars for messages using a `SnackbarHost`.

**Application Configuration:**

* Updated `AndroidManifest.xml` to specify the custom `android:name` attribute for the application, registering the `MarketApp` class as the application entry point.- Register `MarketApp` in `AndroidManifest.xml`.
- Implement `ProductListUiState` and `ProductListEvent` to manage screen states and one-time events.
- Update `ProductListViewModel` to expose `uiState` via `StateFlow` and `events` via `SharedFlow`.
- Implement `ProductListScreen` with `Scaffold`, handling `Loading`, `Error`, and `Success` states.
- Add `LaunchedEffect` in `ProductListScreen` to collect and display snackbar messages from ViewModel events.