### PR TITLE
Set up networking infrastructure and Dagger/Hilt NetworkModule

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     kotlin{
         jvmToolchain(17)
@@ -92,6 +93,9 @@ dependencies {
     implementation(libs.converter.kotlinx.serialization)
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging.interceptor)
+
+    //Serialization
+    implementation(libs.kotlinx.serialization.json)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/di/NetworkModule.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/di/NetworkModule.kt
@@ -1,0 +1,74 @@
+package com.amrubio27.cursotestingandroid.di
+
+import com.amrubio27.cursotestingandroid.BuildConfig
+import com.amrubio27.cursotestingandroid.productlist.data.remote.MiniMarketApiService
+import dagger.Provides
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import java.util.concurrent.TimeUnit
+import javax.inject.Named
+import javax.inject.Singleton
+
+object NetworkModule {
+
+    @Provides
+    @Singleton
+    @Named("baseUrl")
+    fun provideBaseUrl(): String {
+        return "https://raw.githubusercontent.com/amrubio27/minimarket-api/main/"
+    }
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(): OkHttpClient {
+        val logginInterceptor: HttpLoggingInterceptor = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+
+        val builder = OkHttpClient.Builder()
+        if (BuildConfig.DEBUG) {
+            builder.addInterceptor(logginInterceptor)
+        }
+        return builder
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideJson(): Json {
+        return Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+            coerceInputValues = true
+        }
+    }
+
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(
+        okHttpClient: OkHttpClient,
+        json: Json,
+        @Named("baseUrl") baseUrl: String
+    ): Retrofit {
+        val contentType = "application/json".toMediaType()
+        return Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .client(okHttpClient)
+            .addConverterFactory(json.asConverterFactory(contentType))
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideMiniMarketApiService(retrofit: Retrofit): MiniMarketApiService {
+        return retrofit.create(MiniMarketApiService::class.java)
+    }
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/di/NetworkModule.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/di/NetworkModule.kt
@@ -13,6 +13,8 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Named
 import javax.inject.Singleton
 
+//@Module
+//@InstallIn(SingletonComponent::class)
 object NetworkModule {
 
     @Provides


### PR DESCRIPTION
This pull request introduces a new `NetworkModule` for dependency injection, configuring network-related dependencies such as Retrofit, OkHttp, and JSON serialization. It also updates the Gradle build configuration to support these changes.

**Dependency Injection and Networking:**

* Added a new `NetworkModule` object in `NetworkModule.kt` that provides singleton instances for the base URL, OkHttp client (with logging in debug mode), a configured `Json` instance, a Retrofit instance with Kotlinx Serialization, and the `MiniMarketApiService` interface. This sets up a robust and testable network layer using Dagger.

**Build Configuration and Dependencies:**

* Enabled `buildConfig` generation in the `android` block of `build.gradle.kts`, allowing runtime access to `BuildConfig` constants like `DEBUG`.
* Added `kotlinx.serialization.json` as a dependency in `build.gradle.kts` to enable JSON serialization/deserialization with Kotlinx Serialization.- Enable `buildConfig` and add `kotlinx-serialization-json` dependency in `build.gradle.kts`.
- Create `NetworkModule` to provide singleton instances for networking.
- Configure `OkHttpClient` with `HttpLoggingInterceptor` (for debug builds) and 30-second timeouts.
- Configure `Retrofit` with `kotlinx-serialization` converter and a base URL.
- Provide `MiniMarketApiService` for dependency injection.