### PR TITLE
Implement coroutine dispatcher provider and update product repository

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/core/data/coroutines/DefaultDispatchersProvider.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/core/data/coroutines/DefaultDispatchersProvider.kt
@@ -1,0 +1,12 @@
+package com.amrubio27.cursotestingandroid.core.data.coroutines
+
+import com.amrubio27.cursotestingandroid.core.domain.coroutines.DispatchersProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Inject
+
+class DefaultDispatchersProvider @Inject constructor() : DispatchersProvider {
+    override val main: CoroutineDispatcher = Dispatchers.Main
+    override val io: CoroutineDispatcher = Dispatchers.IO
+    override val default: CoroutineDispatcher = Dispatchers.Default
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/core/domain/coroutines/DispatchersProvider.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/core/domain/coroutines/DispatchersProvider.kt
@@ -1,0 +1,9 @@
+package com.amrubio27.cursotestingandroid.core.domain.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+
+interface DispatchersProvider {
+    val main: CoroutineDispatcher
+    val io: CoroutineDispatcher
+    val default: CoroutineDispatcher
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/di/DataModule.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/di/DataModule.kt
@@ -1,0 +1,32 @@
+package com.amrubio27.cursotestingandroid.di
+
+import com.amrubio27.cursotestingandroid.core.data.coroutines.DefaultDispatchersProvider
+import com.amrubio27.cursotestingandroid.core.domain.coroutines.DispatchersProvider
+import com.amrubio27.cursotestingandroid.productlist.data.repository.ProductRepositoryImpl
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DataModule {
+    @Provides
+    @Singleton
+    fun provideDispatchersProvider(
+        defaultDispatchersProvider: DefaultDispatchersProvider
+    ): DispatchersProvider {
+        return DefaultDispatchersProvider()
+    }
+
+    @Provides
+    @Singleton
+    fun provideProductRepository(
+        productRepositoryImpl: ProductRepositoryImpl
+    ): ProductRepository {
+        return productRepositoryImpl
+    }
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/repository/ProductRepositoryImpl.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/repository/ProductRepositoryImpl.kt
@@ -1,11 +1,17 @@
 package com.amrubio27.cursotestingandroid.productlist.data.repository
 
+import com.amrubio27.cursotestingandroid.core.domain.coroutines.DispatchersProvider
+import com.amrubio27.cursotestingandroid.productlist.data.remote.RemoteDataSource
 import com.amrubio27.cursotestingandroid.productlist.domain.model.Product
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-class ProductRepositoryImpl @Inject constructor() : ProductRepository {
+class ProductRepositoryImpl @Inject constructor(
+    val remoteDataSource: RemoteDataSource,
+    val dispatchersProvider: DispatchersProvider
+) : ProductRepository {
     override fun getProducts(): Flow<List<Product>> {
         TODO("Not yet implemented")
     }
@@ -15,6 +21,8 @@ class ProductRepositoryImpl @Inject constructor() : ProductRepository {
     }
 
     override suspend fun refreshProducts() {
-        TODO("Not yet implemented")
+        withContext(dispatchersProvider.io) {
+            val result = remoteDataSource.getProducts()
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces dependency injection for coroutine dispatchers and restructures the data layer to improve testability and maintainability. The main changes include creating a `DispatchersProvider` interface and its implementation, wiring them up via a Dagger-Hilt module, and refactoring the `ProductRepositoryImpl` to use these injected dependencies.

**Dependency injection and coroutine dispatchers:**
- Added a new `DispatchersProvider` interface in `core.domain.coroutines` to abstract coroutine dispatchers, and implemented it with `DefaultDispatchersProvider` in `core.data.coroutines`. This allows for easier testing and decouples the code from the default dispatchers. [[1]](diffhunk://#diff-a4b11b006f312168def638908eb9c7aedafb59b75ec75708371b996efaba3ae5R1-R9) [[2]](diffhunk://#diff-5901d9cd9c38ec051df6bd35d8a38e5281a2476b4465d763d2a24a9d3448b614R1-R12)
- Created a new Dagger-Hilt `DataModule` to provide singleton instances of `DispatchersProvider` and `ProductRepository`, ensuring dependencies are injected throughout the app.

**Repository refactoring:**
- Updated `ProductRepositoryImpl` to receive `RemoteDataSource` and `DispatchersProvider` via constructor injection, improving testability and aligning with dependency injection best practices.
- Modified the `refreshProducts` method in `ProductRepositoryImpl` to use `withContext(dispatchersProvider.io)` when calling `remoteDataSource.getProducts()`, ensuring network operations run on the appropriate coroutine dispatcher.- Define `DispatchersProvider` interface and its default implementation for coroutine management.
- Inject `RemoteDataSource` and `DispatchersProvider` into `ProductRepositoryImpl`.
- Implement `refreshProducts` in the repository using the IO dispatcher.
- Create `DataModule` to configure Hilt dependency injection for data layer components.