### PR TITLE
Implement local data persistence and update Product repository

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/LocalDataSource.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/LocalDataSource.kt
@@ -1,0 +1,17 @@
+package com.amrubio27.cursotestingandroid.productlist.data.local
+
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.dao.ProductDao
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.dao.PromotionDao
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.entity.ProductEntity
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class LocalDataSource @Inject constructor(
+    private val productDao: ProductDao,
+    private val promotionDao: PromotionDao
+) {
+    fun getAllProducts(): Flow<List<ProductEntity>> = productDao.getProducts()
+
+    suspend fun saveProducts(products: List<ProductEntity>) = productDao.replaceAll(products)
+
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/MiniMarketDatabase.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/MiniMarketDatabase.kt
@@ -1,0 +1,22 @@
+package com.amrubio27.cursotestingandroid.productlist.data.local.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.dao.ProductDao
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.dao.PromotionDao
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.entity.ProductEntity
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.entity.PromotionEntity
+
+@Database(
+    entities = [
+        ProductEntity::class,
+        PromotionEntity::class
+    ],
+    version = 1,
+    exportSchema = true
+)
+
+abstract class MiniMarketDatabase : RoomDatabase() {
+    abstract fun productDao(): ProductDao
+    abstract fun promotionDao(): PromotionDao
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/dao/ProductDao.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/dao/ProductDao.kt
@@ -1,0 +1,30 @@
+package com.amrubio27.cursotestingandroid.productlist.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.entity.ProductEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ProductDao {
+    @Query("SELECT * FROM products")
+    fun getProducts(): Flow<List<ProductEntity>>
+
+    @Query("SELECT * FROM products WHERE id = :id")
+    fun getProductById(id: String): Flow<ProductEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAllProducts(products: List<ProductEntity>)
+
+    @Query("DELETE FROM products")
+    suspend fun clearProducts()
+
+    @Transaction
+    suspend fun replaceAll(products: List<ProductEntity>) {
+        clearProducts()
+        insertAllProducts(products)
+    }
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/dao/PromotionDao.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/dao/PromotionDao.kt
@@ -1,0 +1,27 @@
+package com.amrubio27.cursotestingandroid.productlist.data.local.database.dao
+
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.entity.PromotionEntity
+import kotlinx.coroutines.flow.Flow
+
+interface PromotionDao {
+    @Query("SELECT * FROM promotions")
+    fun getAllPromotions(): Flow<List<PromotionEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertPromotions(promotions: List<PromotionEntity>)
+
+    @Query("DELETE FROM promotions")
+    suspend fun clearPromotions()
+
+    @Transaction
+    suspend fun replaceAll(promotions: List<PromotionEntity>) {
+        clearPromotions()
+        insertPromotions(promotions)
+    }
+
+
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/entity/ProductEntity.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/entity/ProductEntity.kt
@@ -1,0 +1,15 @@
+package com.amrubio27.cursotestingandroid.productlist.data.local.database.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "products")
+data class ProductEntity(
+    @PrimaryKey val id: String,
+    val name: String,
+    val description: String?,
+    val price: Double,
+    val category: String?,
+    val stock: Int?,
+    val imageUrl: String? = null
+)

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/entity/PromotionEntity.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/entity/PromotionEntity.kt
@@ -1,0 +1,17 @@
+package com.amrubio27.cursotestingandroid.productlist.data.local.database.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "promotions")
+data class PromotionEntity(
+    @PrimaryKey
+    val id: String,
+    val productId: String,
+    val type: String,
+    val percent: Int? = null,
+    val buyX: Int? = null,
+    val payY: Int? = null,
+    val startAtEpoch: Long? = null,
+    val endAtEpoch: Long? = null
+)

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/mappers/ProductMapper.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/mappers/ProductMapper.kt
@@ -1,0 +1,33 @@
+package com.amrubio27.cursotestingandroid.productlist.data.mappers
+
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.entity.ProductEntity
+import com.amrubio27.cursotestingandroid.productlist.data.remote.response.ProductResponse
+import com.amrubio27.cursotestingandroid.productlist.domain.model.Product
+
+fun ProductResponse.toEntity(): ProductEntity {
+    val finalPrice = priceCents?.div(100.0) ?: 0.0
+
+    return ProductEntity(
+        id = id,
+        name = name,
+        description = description,
+        price = finalPrice,
+        category = category,
+        stock = stock,
+        imageUrl = imageUrl
+    )
+}
+
+fun ProductEntity.toDomain(): Product? {
+    if (category.isNullOrEmpty()) return null
+
+    return Product(
+        id = id,
+        name = name,
+        description = description.orEmpty(),
+        price = price,
+        category = category,
+        stock = stock ?: 0,
+        imageUrl = imageUrl
+    )
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/repository/ProductRepositoryImpl.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/repository/ProductRepositoryImpl.kt
@@ -1,19 +1,54 @@
 package com.amrubio27.cursotestingandroid.productlist.data.repository
 
 import com.amrubio27.cursotestingandroid.core.domain.coroutines.DispatchersProvider
+import com.amrubio27.cursotestingandroid.productlist.data.local.LocalDataSource
+import com.amrubio27.cursotestingandroid.productlist.data.mappers.toDomain
+import com.amrubio27.cursotestingandroid.productlist.data.mappers.toEntity
 import com.amrubio27.cursotestingandroid.productlist.data.remote.RemoteDataSource
 import com.amrubio27.cursotestingandroid.productlist.domain.model.Product
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class ProductRepositoryImpl @Inject constructor(
     val remoteDataSource: RemoteDataSource,
+    val localDataSource: LocalDataSource,
     val dispatchersProvider: DispatchersProvider
 ) : ProductRepository {
+    private val refreshScope = CoroutineScope(SupervisorJob() + dispatchersProvider.io)
+    private val refreshMutex = Mutex()
+
+
     override fun getProducts(): Flow<List<Product>> {
-        TODO("Not yet implemented")
+        return localDataSource.getAllProducts()
+            .map { entities ->
+                entities.mapNotNull {
+                    it.toDomain()
+                }
+            }
+            .onStart {
+                refreshScope.launch {
+                    if (!refreshMutex.tryLock()) return@launch
+                    try {
+                        refreshProducts()
+                    } catch (e: Exception) {
+                    } finally {
+                        refreshMutex.unlock()
+                    }
+
+                }
+            }
+            .catch {
+                //Log
+            }
     }
 
     override fun getProductById(id: String): Flow<Product?> {
@@ -22,7 +57,10 @@ class ProductRepositoryImpl @Inject constructor(
 
     override suspend fun refreshProducts() {
         withContext(dispatchersProvider.io) {
-            val result = remoteDataSource.getProducts()
+            val products = remoteDataSource.getProducts().getOrThrow()
+            val productsEntity = products.map { it.toEntity() }
+            localDataSource.saveProducts(productsEntity)
+
         }
     }
 }


### PR DESCRIPTION
- Set up Room database with `ProductEntity`, `PromotionEntity`, and corresponding DAOs.
- Create `LocalDataSource` to encapsulate database operations for products and promotions.
- Implement `ProductMapper` to handle conversions between Remote, Entity, and Domain models.
- Update `ProductRepositoryImpl` to fetch data from `LocalDataSource` and trigger background refreshes via `RemoteDataSource`.
- Add concurrency control using a Mutex in the repository to pr
This pull request introduces a local Room database layer for product and promotion data, and integrates it into the product repository. The main goal is to enable offline access and caching of products, with automatic refreshing from the remote source. The changes include new data entities, DAOs, a database definition, data mappers, and updates to the repository logic.

**Room Database Integration**

* Added `MiniMarketDatabase` as the Room database, including `ProductEntity` and `PromotionEntity` as entities, and providing DAOs for both (`MiniMarketDatabase.kt`).
* Created `ProductEntity` and `PromotionEntity` data classes to represent products and promotions in the local database (`ProductEntity.kt`, `PromotionEntity.kt`). [[1]](diffhunk://#diff-b9b28f418d3afac2cb3d032ff3a4a5d3313ce07b9487e9b0e46b141e0273d26fR1-R15) [[2]](diffhunk://#diff-34b0c0fd4d68692506b47c9dadb290d36f5f0575a53671c367ee89552bcd6c15R1-R17)
* Implemented DAOs: `ProductDao` and `PromotionDao` for CRUD operations and transactional replacements of products and promotions (`ProductDao.kt`, `PromotionDao.kt`). [[1]](diffhunk://#diff-66ae2e8296204c930ef28b298ecec3d09cfff3214a42ab8e914853730492a133R1-R30) [[2]](diffhunk://#diff-c3788013bee1f9d2802a1c8e16e42914dd59175afc272e8148d59b20e4d56928R1-R27)

**Data Layer and Repository Updates**

* Added `LocalDataSource` to abstract local database access for products and promotions (`LocalDataSource.kt`).
* Updated `ProductRepositoryImpl` to:
  * Use `LocalDataSource` for product retrieval and persistence.
  * Implement a refresh mechanism that fetches products from the remote source, saves them locally, and exposes local data as a `Flow`.
  * Map between remote, local, and domain models using new mappers. [[1]](diffhunk://#diff-dbd2a1f3f3352b1d6c38c555092a5678b0aee750e6d5947d0559dccaaf6f18a4R4-R51) [[2]](diffhunk://#diff-dbd2a1f3f3352b1d6c38c555092a5678b0aee750e6d5947d0559dccaaf6f18a4L25-R63)

**Data Mapping**

* Added mappers to convert between `ProductResponse`, `ProductEntity`, and domain `Product` models (`ProductMapper.kt`).event redundant refresh calls.