### PR TITLE
Implement product list data flow and database configuration

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/navigation/NavGraph.kt
@@ -2,22 +2,21 @@ package com.amrubio27.cursotestingandroid.core.presentation.navigation
 
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavGraph
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
+import com.amrubio27.cursotestingandroid.productlist.presentation.ProductListScreen
 
 @Composable
 fun NavGraph() {
     val backStack: NavBackStack<NavKey> = rememberNavBackStack(Screen.ProductList)
     val entries: (NavKey) -> NavEntry<NavKey> = entryProvider<NavKey> {
         entry<Screen.ProductList> {
-            Text("ProductList", fontSize = 30.sp)
+            ProductListScreen()
         }
         entry<Screen.Cart> {
             Text("Cart", fontSize = 30.sp)

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/di/DataModule.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/di/DataModule.kt
@@ -1,12 +1,18 @@
 package com.amrubio27.cursotestingandroid.di
 
+import android.content.Context
+import androidx.room.Room
 import com.amrubio27.cursotestingandroid.core.data.coroutines.DefaultDispatchersProvider
 import com.amrubio27.cursotestingandroid.core.domain.coroutines.DispatchersProvider
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.MiniMarketDatabase
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.dao.ProductDao
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.dao.PromotionDao
 import com.amrubio27.cursotestingandroid.productlist.data.repository.ProductRepositoryImpl
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
@@ -28,5 +34,21 @@ object DataModule {
         productRepositoryImpl: ProductRepositoryImpl
     ): ProductRepository {
         return productRepositoryImpl
+    }
+
+    @Provides
+    fun provideProductDao(database: MiniMarketDatabase): ProductDao = database.productDao()
+
+    @Provides
+    fun providePromotionDao(database: MiniMarketDatabase): PromotionDao = database.promotionDao()
+
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): MiniMarketDatabase {
+        return Room.databaseBuilder(
+            context,
+            MiniMarketDatabase::class.java,
+            "market_db"
+        ).build()
     }
 }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/di/NetworkModule.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/di/NetworkModule.kt
@@ -2,7 +2,10 @@ package com.amrubio27.cursotestingandroid.di
 
 import com.amrubio27.cursotestingandroid.BuildConfig
 import com.amrubio27.cursotestingandroid.productlist.data.remote.MiniMarketApiService
+import dagger.Module
 import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -13,8 +16,8 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Named
 import javax.inject.Singleton
 
-//@Module
-//@InstallIn(SingletonComponent::class)
+@Module
+@InstallIn(SingletonComponent::class)
 object NetworkModule {
 
     @Provides

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/dao/PromotionDao.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/dao/PromotionDao.kt
@@ -1,5 +1,6 @@
 package com.amrubio27.cursotestingandroid.productlist.data.local.database.dao
 
+import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
@@ -7,6 +8,7 @@ import androidx.room.Transaction
 import com.amrubio27.cursotestingandroid.productlist.data.local.database.entity.PromotionEntity
 import kotlinx.coroutines.flow.Flow
 
+@Dao
 interface PromotionDao {
     @Query("SELECT * FROM promotions")
     fun getAllPromotions(): Flow<List<PromotionEntity>>

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetProductsUseCase.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetProductsUseCase.kt
@@ -1,0 +1,15 @@
+package com.amrubio27.cursotestingandroid.productlist.domain.usecase
+
+import com.amrubio27.cursotestingandroid.productlist.domain.model.Product
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetProductsUseCase @Inject constructor(
+    private val productRepository: ProductRepository
+) {
+    operator fun invoke(): Flow<List<Product>> {
+        //de momento, ahora no seria necesario pero para más adelante si nos hace falta el caso de uso
+        return productRepository.getProducts()
+    }
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreen.kt
@@ -1,9 +1,14 @@
 package com.amrubio27.cursotestingandroid.productlist.presentation
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -16,9 +21,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.amrubio27.cursotestingandroid.productlist.domain.model.Product
 
 @Composable
 fun ProductListScreen(
@@ -76,7 +83,19 @@ fun ProductListScreen(
                         .fillMaxSize()
                         .padding(paddingValues)
                 ) {
-                    state.selectedCategory
+                    LazyColumn {
+                        items(state.products) { product: Product ->
+                            Box(
+                                Modifier
+                                    .fillMaxWidth()
+                                    .height(50.dp)
+                                    .background(Color.Red),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(product.name)
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListUiState.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListUiState.kt
@@ -1,12 +1,14 @@
 package com.amrubio27.cursotestingandroid.productlist.presentation
 
+import com.amrubio27.cursotestingandroid.productlist.domain.model.Product
+
 sealed class ProductListUiState {
     data object Loading : ProductListUiState()
     data class Error(val message: String) : ProductListUiState()
     data class Success(
-        //val products: List<>,
+        val products: List<Product>, //de momento usamos el modelo de dominio, luego creamos uno de ui
         //val categories:List<>.
-        val selectedCategory: String,
+        //val selectedCategory: String,
         //sortOption
     ) : ProductListUiState()
 

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListViewModel.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListViewModel.kt
@@ -1,6 +1,9 @@
 package com.amrubio27.cursotestingandroid.productlist.presentation
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.amrubio27.cursotestingandroid.productlist.domain.model.Product
+import com.amrubio27.cursotestingandroid.productlist.domain.usecase.GetProductsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jakarta.inject.Inject
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -8,9 +11,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 @HiltViewModel
-class ProductListViewModel @Inject constructor() : ViewModel() {
+class ProductListViewModel @Inject constructor(
+    private val getProductsUseCase: GetProductsUseCase
+) : ViewModel() {
     private val _uiState = MutableStateFlow<ProductListUiState>(ProductListUiState.Loading)
     val uiState: StateFlow<ProductListUiState> = _uiState.asStateFlow()
 
@@ -23,8 +31,14 @@ class ProductListViewModel @Inject constructor() : ViewModel() {
 
     fun loadProducts() {
         _uiState.value = ProductListUiState.Loading
+        getProductsUseCase()
+            .onEach { products: List<Product> ->
+                _uiState.value = ProductListUiState.Success(products)
+            }
+            .catch { exception: Throwable ->
+                _uiState.value = ProductListUiState.Error(exception.message.orEmpty())
+            }
+            .launchIn(viewModelScope)
+
     }
-
-
-
 }


### PR DESCRIPTION
This pull request introduces several significant improvements to the product list feature, focusing on integrating Room database access, enhancing dependency injection, and improving the product list UI and state management. The changes set up the necessary infrastructure for local data storage, update the UI to display products using a `LazyColumn`, and implement a use case and ViewModel logic for loading products.

**Dependency Injection and Database Integration:**

* Added Room database setup (`MiniMarketDatabase`) with Dagger/Hilt providers for the database and DAOs (`ProductDao`, `PromotionDao`) in `DataModule.kt`, enabling local data access and persistence. [[1]](diffhunk://#diff-ef31b39b2f33ffe67829becffa7d051e40f55a65647c3b02720ec302f5f71b78R3-R15) [[2]](diffhunk://#diff-ef31b39b2f33ffe67829becffa7d051e40f55a65647c3b02720ec302f5f71b78R38-R53)
* Marked `PromotionDao` with the `@Dao` annotation, ensuring Room recognizes it as a DAO.

**Network Layer Improvements:**

* Enabled Dagger/Hilt module setup for the network layer by uncommenting and annotating `NetworkModule` with `@Module` and `@InstallIn(SingletonComponent::class)`, facilitating dependency injection for network components. [[1]](diffhunk://#diff-5ff4129cfc6bfdf37bbb6d73b6e63c432b3a1aa171cc6c46c84eaf450db87cc3R5-R8) [[2]](diffhunk://#diff-5ff4129cfc6bfdf37bbb6d73b6e63c432b3a1aa171cc6c46c84eaf450db87cc3L16-R20)

**Product List Feature Enhancements:**

* Implemented the `GetProductsUseCase` to encapsulate the logic for retrieving products from the repository, supporting clean architecture principles.
* Updated `ProductListViewModel` to use the new use case and handle loading, success, and error states with proper state flow and coroutine handling. [[1]](diffhunk://#diff-b6f5340fe336eca2fb55d153b98eedd929b4b0b9d413c2313365ba5cf8361563R4-R21) [[2]](diffhunk://#diff-b6f5340fe336eca2fb55d153b98eedd929b4b0b9d413c2313365ba5cf8361563R34-R43)
* Modified `ProductListUiState` to include a list of domain `Product` objects, simplifying state management and preparing for future UI model separation.

**UI and Navigation Updates:**

* Updated `ProductListScreen` to display products in a `LazyColumn`, improving the UI by showing each product's name in a list format. [[1]](diffhunk://#diff-7eefad4153d025cf84ca2f696ddca1bd49d94f87e8c239eb7fc8d79dc2ed3a25R3-R11) [[2]](diffhunk://#diff-7eefad4153d025cf84ca2f696ddca1bd49d94f87e8c239eb7fc8d79dc2ed3a25R24-R28) [[3]](diffhunk://#diff-7eefad4153d025cf84ca2f696ddca1bd49d94f87e8c239eb7fc8d79dc2ed3a25L79-R98)
* Changed the navigation graph to use the new `ProductListScreen` composable instead of a placeholder text, integrating the UI into the app's navigation flow.- Set up Room database and provide `ProductDao` and `PromotionDao` in `DataModule`.
- Enable Hilt `@Module` and `@InstallIn` annotations in `NetworkModule`.
- Implement `GetProductsUseCase` to bridge the repository and ViewModel.
- Update `ProductListViewModel` to fetch products using the new use case and handle UI state transitions.
- Update `ProductListUiState` to hold a list of `Product` domain models.
- Enhance `ProductListScreen` to display the product list using a `LazyColumn`.
- Integrate `ProductListScreen` into the `NavGraph` navigation structure.
- Add missing `@Dao` annotation to `PromotionDao`.