### PR TITLE
Implement Promotion domain model and repository

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/di/DataModule.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/di/DataModule.kt
@@ -8,6 +8,7 @@ import com.amrubio27.cursotestingandroid.productlist.data.local.database.MiniMar
 import com.amrubio27.cursotestingandroid.productlist.data.local.database.dao.ProductDao
 import com.amrubio27.cursotestingandroid.productlist.data.local.database.dao.PromotionDao
 import com.amrubio27.cursotestingandroid.productlist.data.repository.ProductRepositoryImpl
+import com.amrubio27.cursotestingandroid.productlist.data.repository.PromotionRepositoryImpl
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
 import dagger.Module
 import dagger.Provides
@@ -35,6 +36,15 @@ object DataModule {
     ): ProductRepository {
         return productRepositoryImpl
     }
+
+    @Provides
+    @Singleton
+    fun providePromotionRepository(
+        promotionRepositoryImpl: PromotionRepositoryImpl
+    ): PromotionRepositoryImpl {
+        return promotionRepositoryImpl
+    }
+
 
     @Provides
     fun provideProductDao(database: MiniMarketDatabase): ProductDao = database.productDao()

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/LocalDataSource.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/LocalDataSource.kt
@@ -3,6 +3,7 @@ package com.amrubio27.cursotestingandroid.productlist.data.local
 import com.amrubio27.cursotestingandroid.productlist.data.local.database.dao.ProductDao
 import com.amrubio27.cursotestingandroid.productlist.data.local.database.dao.PromotionDao
 import com.amrubio27.cursotestingandroid.productlist.data.local.database.entity.ProductEntity
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.entity.PromotionEntity
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
@@ -13,5 +14,8 @@ class LocalDataSource @Inject constructor(
     fun getAllProducts(): Flow<List<ProductEntity>> = productDao.getProducts()
 
     suspend fun saveProducts(products: List<ProductEntity>) = productDao.replaceAll(products)
+
+    suspend fun savePromotions(promotions: List<PromotionEntity>) =
+        promotionDao.replaceAll(promotions)
 
 }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/entity/PromotionEntity.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/entity/PromotionEntity.kt
@@ -7,7 +7,7 @@ import androidx.room.PrimaryKey
 data class PromotionEntity(
     @PrimaryKey
     val id: String,
-    val productId: String,
+    val productIds: String,
     val type: String,
     val percent: Int? = null,
     val buyX: Int? = null,

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/mappers/PromotionsMapper.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/mappers/PromotionsMapper.kt
@@ -1,0 +1,28 @@
+package com.amrubio27.cursotestingandroid.productlist.data.mappers
+
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.entity.PromotionEntity
+import com.amrubio27.cursotestingandroid.productlist.data.remote.response.PromotionResponse
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+
+fun PromotionResponse.toEntity(json: Json): PromotionEntity? {
+    if (startAtEpoch == null || endAtEpoch == null) return null
+
+    val productIds = listOf(productId)
+    val productIdsJson = json.encodeToString(
+        ListSerializer(String.serializer()),
+        productIds
+    )
+
+    return PromotionEntity(
+        id = id,
+        type = type,
+        productIds = productIdsJson,
+        percent = percent,
+        buyX = buyX,
+        payY = payY,
+        startAtEpoch = startAtEpoch,
+        endAtEpoch = endAtEpoch
+    )
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/repository/ProductRepositoryImpl.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/repository/ProductRepositoryImpl.kt
@@ -19,9 +19,9 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class ProductRepositoryImpl @Inject constructor(
-    val remoteDataSource: RemoteDataSource,
-    val localDataSource: LocalDataSource,
-    val dispatchersProvider: DispatchersProvider
+    private val remoteDataSource: RemoteDataSource,
+    private val localDataSource: LocalDataSource,
+    private val dispatchersProvider: DispatchersProvider
 ) : ProductRepository {
     private val refreshScope = CoroutineScope(SupervisorJob() + dispatchersProvider.io)
     private val refreshMutex = Mutex()

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/repository/PromotionRepositoryImpl.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/repository/PromotionRepositoryImpl.kt
@@ -1,0 +1,34 @@
+package com.amrubio27.cursotestingandroid.productlist.data.repository
+
+import com.amrubio27.cursotestingandroid.core.domain.coroutines.DispatchersProvider
+import com.amrubio27.cursotestingandroid.productlist.data.local.LocalDataSource
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.entity.PromotionEntity
+import com.amrubio27.cursotestingandroid.productlist.data.mappers.toEntity
+import com.amrubio27.cursotestingandroid.productlist.data.remote.RemoteDataSource
+import com.amrubio27.cursotestingandroid.productlist.domain.model.Promotion
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.PromotionRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+
+class PromotionRepositoryImpl @Inject constructor(
+    private val remoteDataSource: RemoteDataSource,
+    private val localDataSource: LocalDataSource,
+    private val dispatchersProvider: DispatchersProvider,
+    private val json: Json
+) : PromotionRepository {
+    override fun getActivePromotions(): Flow<List<Promotion>> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun refreshPromotions() {
+        withContext(dispatchersProvider.io) {
+            val promotions = remoteDataSource.getPromotions().getOrThrow()
+            val promotionsEntity: List<PromotionEntity> =
+                promotions.mapNotNull { it.toEntity(json) }
+            localDataSource.savePromotions(promotionsEntity)
+
+        }
+    }
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/domain/model/Promotion.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/domain/model/Promotion.kt
@@ -1,0 +1,18 @@
+package com.amrubio27.cursotestingandroid.productlist.domain.model
+
+import kotlin.time.Instant
+
+enum class PromotionType {
+    PERCENT,
+    BUY_X_PAY_Y
+}
+
+data class Promotion(
+    val id: String,
+    val type: PromotionType,
+    val productIds: List<String>,
+    val value: Double,
+    val buyQuantity: Int? = null,
+    val startTime: Instant,
+    val endTime: Instant
+)

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/domain/repository/PromotionRepository.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/domain/repository/PromotionRepository.kt
@@ -1,0 +1,9 @@
+package com.amrubio27.cursotestingandroid.productlist.domain.repository
+
+import com.amrubio27.cursotestingandroid.productlist.domain.model.Promotion
+import kotlinx.coroutines.flow.Flow
+
+interface PromotionRepository {
+    fun getActivePromotions(): Flow<List<Promotion>>
+    suspend fun refreshPromotions()
+}


### PR DESCRIPTION
This pull request introduces support for handling promotions in the product list feature. It adds the domain model, repository, and data mapping for promotions, as well as updates the local data source and entity structure to accommodate the new functionality. The changes lay the groundwork for fetching, storing, and mapping promotions from remote to local storage.

**Promotion support implementation:**

* Added the `PromotionRepositoryImpl` class, which implements the new `PromotionRepository` interface and provides methods for refreshing promotions from the remote data source and saving them locally. [[1]](diffhunk://#diff-928d4f4acff95cba8380663f0a9e8d26bfbe3491ef31c70ddd75f8d6dfd996f6R1-R34) [[2]](diffhunk://#diff-87b75a0aa13de74453833a89cbdc29f3e4dfd0de6d5a6897da2af2fa53ed6e95R1-R9)
* Introduced the `Promotion` domain model and `PromotionType` enum to represent promotions in the business logic layer.
* Implemented a mapper (`toEntity`) to convert `PromotionResponse` objects from the remote API into `PromotionEntity` objects for local storage, serializing product IDs as a JSON string.

**Local data and dependency injection updates:**

* Updated the `PromotionEntity` data class to store a list of product IDs as a JSON string instead of a single product ID.
* Extended `LocalDataSource` to support saving promotions, and updated the dependency injection module (`DataModule`) to provide the new `PromotionRepositoryImpl`. [[1]](diffhunk://#diff-01b5d3542320806fba15247b6d5aa0bf9800e672097515d15c51a66ff6a1ed88R6) [[2]](diffhunk://#diff-01b5d3542320806fba15247b6d5aa0bf9800e672097515d15c51a66ff6a1ed88R18-R20) [[3]](diffhunk://#diff-ef31b39b2f33ffe67829becffa7d051e40f55a65647c3b02720ec302f5f71b78R11) [[4]](diffhunk://#diff-ef31b39b2f33ffe67829becffa7d051e40f55a65647c3b02720ec302f5f71b78R40-R48)

**Other improvements:**

* Made constructor parameters in `ProductRepositoryImpl` private for better encapsulation.- Add `Promotion` domain model and `PromotionType` enum.
- Define `PromotionRepository` interface and its implementation `PromotionRepositoryImpl`.
- Update `PromotionEntity` to handle multiple product IDs as a JSON string.
- Create `PromotionsMapper` to convert `PromotionResponse` to `PromotionEntity`.
- Extend `LocalDataSource` to support saving promotions.
- Register `PromotionRepository` in `DataModule` for dependency injection.
- Refactor `ProductRepositoryImpl` to use private properties for injected dependencies.