### PR TITLE
Core/25/settings repository

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/core/domain/model/ThemeMode.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/core/domain/model/ThemeMode.kt
@@ -1,0 +1,8 @@
+package com.amrubio27.cursotestingandroid.core.domain.model
+
+sealed class ThemeMode(val id: Int) {
+    object SYSTEM : ThemeMode(0)
+    object LIGHT : ThemeMode(1)
+    object DARK : ThemeMode(2)
+
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/di/DataModule.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/di/DataModule.kt
@@ -1,6 +1,9 @@
 package com.amrubio27.cursotestingandroid.di
 
 import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
 import androidx.room.Room
 import com.amrubio27.cursotestingandroid.core.data.coroutines.DefaultDispatchersProvider
 import com.amrubio27.cursotestingandroid.core.domain.coroutines.DispatchersProvider
@@ -9,8 +12,10 @@ import com.amrubio27.cursotestingandroid.productlist.data.local.database.dao.Pro
 import com.amrubio27.cursotestingandroid.productlist.data.local.database.dao.PromotionDao
 import com.amrubio27.cursotestingandroid.productlist.data.repository.ProductRepositoryImpl
 import com.amrubio27.cursotestingandroid.productlist.data.repository.PromotionRepositoryImpl
+import com.amrubio27.cursotestingandroid.productlist.data.repository.SettingsRepositoryImpl
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.PromotionRepository
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.SettingsRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -18,6 +23,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore("settings")
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -60,4 +67,19 @@ object DataModule {
             "market_db"
         ).build()
     }
+
+    @Provides
+    @Singleton
+    fun provideDataStore(@ApplicationContext context: Context): DataStore<Preferences> {
+        return context.dataStore
+    }
+
+    @Provides
+    @Singleton
+    fun provideSettingsRepository(
+        settingsRepositoryImpl: SettingsRepositoryImpl
+    ): SettingsRepository {
+        return settingsRepositoryImpl
+    }
+
 }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/repository/SettingsRepositoryImpl.kt
@@ -1,0 +1,103 @@
+package com.amrubio27.cursotestingandroid.productlist.data.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.amrubio27.cursotestingandroid.core.domain.model.ThemeMode
+import com.amrubio27.cursotestingandroid.productlist.domain.model.SortOption
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class SettingsRepositoryImpl @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+) : SettingsRepository {
+
+    companion object {
+        private val IN_STOCK_ONLY_KEY = booleanPreferencesKey("IN_STOCK_ONLY_KEY")
+        private val FILTERS_VISIBLE_KEY = booleanPreferencesKey("FILTERS_VISIBLE_KEY")
+        private val SELECTED_CATEGORY_KEY = stringPreferencesKey("SELECTED_CATEGORY_KEY")
+        private val THEME_MODE_KEY = intPreferencesKey("THEME_MODE_KEY")
+        private val SORT_OPTION_KEY = stringPreferencesKey("SORT_OPTION_KEY")
+
+    }
+
+    private val dataStoreFlow: Flow<Preferences> = dataStore.data.catch { exception ->
+        if (exception is androidx.datastore.core.IOException) {
+            emit(emptyPreferences())
+        } else {
+            throw exception
+        }
+    }
+
+    override val inStockOnly: Flow<Boolean> =
+        dataStoreFlow.map { preferences -> preferences[IN_STOCK_ONLY_KEY] ?: false }
+
+    override val selectedCategory: Flow<String?> =
+        dataStoreFlow.map { preferences -> preferences[SELECTED_CATEGORY_KEY] }
+
+    override val filtersVisible: Flow<Boolean> =
+        dataStoreFlow.map { preferences -> preferences[FILTERS_VISIBLE_KEY] ?: true }
+
+    override val themeMode: Flow<ThemeMode> = dataStoreFlow.map { preferences ->
+        when (preferences[THEME_MODE_KEY]) {
+            ThemeMode.SYSTEM.id -> ThemeMode.SYSTEM
+            ThemeMode.LIGHT.id -> ThemeMode.LIGHT
+            ThemeMode.DARK.id -> ThemeMode.DARK
+            else -> ThemeMode.SYSTEM
+        }
+    }
+
+    override val sortOption: Flow<SortOption> = dataStoreFlow.map { preferences ->
+        val raw = preferences[SORT_OPTION_KEY]
+        runCatching {
+            SortOption.valueOf(
+                raw ?: SortOption.NONE.name
+            )
+        }.getOrDefault(SortOption.NONE)
+    }
+
+    override suspend fun setInStockOnly(value: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[IN_STOCK_ONLY_KEY] = value
+        }
+    }
+
+    override suspend fun setThemeMode(value: ThemeMode) {
+        dataStore.edit { preferences ->
+            when (value) {
+                ThemeMode.DARK -> preferences[THEME_MODE_KEY] = ThemeMode.DARK.id
+                ThemeMode.LIGHT -> preferences[THEME_MODE_KEY] = ThemeMode.LIGHT.id
+                ThemeMode.SYSTEM -> preferences[THEME_MODE_KEY] = ThemeMode.SYSTEM.id
+            }
+        }
+    }
+
+    override suspend fun setSelectedCategory(value: String?) {
+        dataStore.edit { preferences ->
+            if (value == null) {
+                preferences.remove(SELECTED_CATEGORY_KEY)
+            } else {
+                preferences[SELECTED_CATEGORY_KEY] = value
+            }
+        }
+    }
+
+    override suspend fun setFiltersVisible(value: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[FILTERS_VISIBLE_KEY] = value
+        }
+    }
+
+    override suspend fun setSortOption(value: SortOption) {
+        dataStore.edit { preferences ->
+            preferences[SORT_OPTION_KEY] = value.name
+        }
+    }
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/domain/repository/SettingsRepository.kt
@@ -1,0 +1,19 @@
+package com.amrubio27.cursotestingandroid.productlist.domain.repository
+
+import com.amrubio27.cursotestingandroid.core.domain.model.ThemeMode
+import com.amrubio27.cursotestingandroid.productlist.domain.model.SortOption
+import kotlinx.coroutines.flow.Flow
+
+interface SettingsRepository {
+    val inStockOnly: Flow<Boolean>
+    val themeMode: Flow<ThemeMode>
+    val selectedCategory: Flow<String?>
+    val sortOption: Flow<SortOption>
+    val filtersVisible: Flow<Boolean>
+
+    suspend fun setInStockOnly(value: Boolean)
+    suspend fun setThemeMode(value: ThemeMode)
+    suspend fun setSelectedCategory(value: String?)
+    suspend fun setFiltersVisible(value: Boolean)
+    suspend fun setSortOption(value: SortOption)
+}


### PR DESCRIPTION
This pull request introduces a new settings persistence layer using Jetpack DataStore, enabling the app to save and observe user preferences such as theme mode, sort option, and filter settings. It adds a new `SettingsRepository` abstraction and its implementation, and integrates these into the dependency injection setup.

Key changes:

**Settings Persistence and Repository Implementation:**

* Added the `SettingsRepository` interface to define methods and observable properties for user settings, such as theme mode, selected category, and filter visibility.
* Implemented `SettingsRepositoryImpl`, which uses Jetpack DataStore to persist and observe user settings, handling preferences for theme mode, sorting, filters, and selected category.
* Introduced the `ThemeMode` sealed class to represent possible theme options (system, light, dark) in a type-safe way.

**Dependency Injection Integration:**

* Registered DataStore and `SettingsRepositoryImpl` as singletons in the Hilt `DataModule`, making them available for injection throughout the app. [[1]](diffhunk://#diff-ef31b39b2f33ffe67829becffa7d051e40f55a65647c3b02720ec302f5f71b78R4-R6) [[2]](diffhunk://#diff-ef31b39b2f33ffe67829becffa7d051e40f55a65647c3b02720ec302f5f71b78R15-R18) [[3]](diffhunk://#diff-ef31b39b2f33ffe67829becffa7d051e40f55a65647c3b02720ec302f5f71b78R27-R28) [[4]](diffhunk://#diff-ef31b39b2f33ffe67829becffa7d051e40f55a65647c3b02720ec302f5f71b78R70-R84)