### PR TITLE
Implement persistent product filtering and sorting using SettingsRepo…

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetProductsUseCase.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetProductsUseCase.kt
@@ -3,6 +3,7 @@ package com.amrubio27.cursotestingandroid.productlist.domain.usecase
 import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductWithPromotion
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.PromotionRepository
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.SettingsRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import java.time.Instant
@@ -11,19 +12,27 @@ import javax.inject.Inject
 class GetProductsUseCase @Inject constructor(
     private val productRepository: ProductRepository,
     private val promotionRepository: PromotionRepository,
-    private val getPromotionForProduct: GetPromotionForProduct
+    private val getPromotionForProduct: GetPromotionForProduct,
+    private val settingsRepository: SettingsRepository
 ) {
     operator fun invoke(): Flow<List<ProductWithPromotion>> {
         return combine(
             productRepository.getProducts(),
-            promotionRepository.getActivePromotions()
-        ) { products, promotions ->
+            promotionRepository.getActivePromotions(),
+            settingsRepository.inStockOnly
+        ) { products, promotions, inStockOnly ->
             val now = Instant.now()
             val activePromotions = promotions.filter {
                 it.startTime.isBefore(now) && it.endTime.isAfter(now)
             }
 
-            products.map { product ->
+            val filteredProducts = if (inStockOnly) {
+                products.filter { it.stock > 0 }
+            } else {
+                products
+            }
+
+            filteredProducts.map { product ->
                 val promotion = getPromotionForProduct(product, activePromotions)
                 ProductWithPromotion(product, promotion)
 

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreen.kt
@@ -43,8 +43,6 @@ fun ProductListScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val filtersVisible by productListViewModel.filtersVisible.collectAsStateWithLifecycle()
 
-
-
     LaunchedEffect(Unit) {
         productListViewModel.events.collect { event ->
             when (event) {

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListViewModel.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListViewModel.kt
@@ -2,24 +2,31 @@ package com.amrubio27.cursotestingandroid.productlist.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductPromotion
 import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductWithPromotion
 import com.amrubio27.cursotestingandroid.productlist.domain.model.SortOption
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.SettingsRepository
 import com.amrubio27.cursotestingandroid.productlist.domain.usecase.GetProductsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jakarta.inject.Inject
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 @HiltViewModel
 class ProductListViewModel @Inject constructor(
-    private val getProductsUseCase: GetProductsUseCase
+    private val getProductsUseCase: GetProductsUseCase,
+    private val settingsRepository: SettingsRepository
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<ProductListUiState>(ProductListUiState.Loading)
     val uiState: StateFlow<ProductListUiState> = _uiState.asStateFlow()
@@ -27,9 +34,13 @@ class ProductListViewModel @Inject constructor(
     private val _events = MutableSharedFlow<ProductListEvent>(extraBufferCapacity = 1)
     val events: SharedFlow<ProductListEvent> = _events
 
-    private val _filtersVisible = MutableStateFlow<Boolean>(true)
-    val filtersVisible: StateFlow<Boolean> = _filtersVisible.asStateFlow()
+    val filtersVisible: StateFlow<Boolean> = settingsRepository.filtersVisible.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = false
+    )
 
+    private var productsJob: Job? = null
 
     init {
         loadProducts()
@@ -37,39 +48,78 @@ class ProductListViewModel @Inject constructor(
 
     fun loadProducts() {
         _uiState.value = ProductListUiState.Loading
-        getProductsUseCase()
-            .onEach { products: List<ProductWithPromotion> ->
-                val categories = products.map { it.product.category }.distinct().sorted()
-                _uiState.value =
-                    ProductListUiState.Success(
-                        products = products,
-                        categories = categories,
-                        selectedCategory = null,
-                        sortOption = SortOption.NONE
+        productsJob?.cancel()
+        productsJob = combine(
+            getProductsUseCase(),
+            settingsRepository.selectedCategory,
+            settingsRepository.sortOption
+        ) { products, selectedCategory, sortOption ->
+            var filteredProducts = products
+            if (selectedCategory != null) {
+                filteredProducts =
+                    filteredProducts.filter { it.product.category == selectedCategory }
+            }
+
+            val sorted = when (sortOption) {
+                SortOption.NONE -> filteredProducts
+                SortOption.PRICE_ASC -> filteredProducts.sortedBy { effecticePrice(it) }
+                SortOption.PRICE_DESC -> filteredProducts.sortedByDescending { effecticePrice(it) }
+                SortOption.DISCOUNT ->
+                    //filteredProducts.sortedByDescending { effectiveDiscountPercent(it) }
+                    filteredProducts.sortedWith(
+                        compareByDescending<ProductWithPromotion> {
+                            effectiveDiscountPercent(it)
+                        }.thenBy {
+                            it.promotion == null
+                        }
                     )
             }
-            .catch { exception: Throwable ->
-                _uiState.value = ProductListUiState.Error(exception.message.orEmpty())
-            }
-            .launchIn(viewModelScope)
 
+            val categories = products.map { it.product.category }.distinct().sorted()
+
+            ProductListUiState.Success(
+                products = sorted,
+                categories = categories,
+                selectedCategory = selectedCategory,
+                sortOption = sortOption
+            )
+        }.onEach { state ->
+            _uiState.value = state
+        }.catch { exception: Throwable ->
+            _uiState.value = ProductListUiState.Error(exception.message.orEmpty())
+        }.launchIn(viewModelScope)
     }
 
     fun setCategory(category: String?) {
         viewModelScope.launch {
-            //llamar al settingsRepository
+            settingsRepository.setSelectedCategory(category)
         }
     }
 
     fun setSortOption(sortOption: SortOption) {
         viewModelScope.launch {
-            //llamar al settingsRepository
+            settingsRepository.setSortOption(sortOption)
         }
     }
 
     fun setFilterVisible(showFilter: Boolean) {
         viewModelScope.launch {
-            _filtersVisible.value = showFilter
+            settingsRepository.setFiltersVisible(showFilter)
         }
     }
+
+    private fun effectiveDiscountPercent(item: ProductWithPromotion): Double {
+        return when (val promo = item.promotion) {
+            is ProductPromotion.Percent -> promo.percent
+            else -> 0.0
+        }
+    }
+
+    private fun effecticePrice(item: ProductWithPromotion): Double {
+        return when (val promo = item.promotion) {
+            is ProductPromotion.Percent -> promo.discountPrice
+            else -> item.product.price
+        }
+    }
+
 }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/FiltersMenu.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/FiltersMenu.kt
@@ -93,7 +93,7 @@ fun FiltersMenu(
 
                 FilterChip(
                     selected = state.sortOption == SortOption.DISCOUNT,
-                    onClick = { onSortSelected(SortOption.NONE) },
+                    onClick = { onSortSelected(SortOption.DISCOUNT) },
                     label = { Text("Descuento", style = MaterialTheme.typography.labelSmall) },
                     modifier = Modifier.weight(1f)
                 )


### PR DESCRIPTION
## 📝 Descripción
Este PR establece el flujo reactivo unidireccional completo desde las preferencias del usuario (DataStore/SettingsRepository) hasta la capa de presentación (UI). Implementa el filtrado, la ordenación y la aplicación de promociones en tiempo real utilizando operadores de Kotlin Flow (`combine`).

## 🛠 Cambios Principales y Justificación Técnica

### 1. Capa de Dominio: `GetProductsUseCase`
* **Reactividad con `combine`:** Se unifican los flujos de `ProductRepository`, `PromotionRepository` y la preferencia `inStockOnly` del `SettingsRepository`.
* **Separación de Responsabilidades:** El filtrado por `inStockOnly` se aplica estrictamente aquí. Las reglas de negocio determinan que la evaluación del stock y la validez temporal de las promociones (`startTime` / `endTime`) no son decisiones de diseño visual, por lo que se aíslan en el dominio. La UI recibe los datos ya cribados.

### 2. Capa de Presentación: `ProductListViewModel`
* **Principio KISS (Keep It Simple, Stupid):** Se inyecta `SettingsRepository` directamente en el ViewModel. Leer o escribir selecciones de filtros visuales no implica lógica de negocio compleja, por lo que se evita la sobreingeniería de crear Casos de Uso intermedios redundantes (*pass-through*).
* **Doble Filtrado Reactivo:** Se implementa un segundo bloque `combine` a nivel de vista para cruzar los datos limpios del UseCase con los filtros activos (`selectedCategory`, `sortOption`). Al modificar un filtro, la vista se repinta instantáneamente sin necesidad de lanzar nuevas peticiones a Room o Retrofit.
* **Optimización de Recursos (`stateIn`):** El estado `filtersVisible` se expone mediante `.stateIn(..., SharingStarted.WhileSubscribed(5000), ...)`. Esto suspende la lectura del DataStore si la app se minimiza, pero tolera rotaciones de pantalla rápidas gracias al margen de 5 segundos, ahorrando batería.
* **Limpieza de Corrutinas:** Se introduce `productsJob?.cancel()`. Dado que el estado principal se sigue disparando de forma imperativa (`loadProducts()`), esta línea es obligatoria para destruir la suscripción anterior antes de crear una nueva, evitando duplicidad de flujos y fugas de memoria.

### 3. Ordenación y Lógica de UI
* **Desempates seguros (`sortedWith`):** Para ordenar por el mejor descuento, se utiliza `compareByDescending` seguido de `thenBy`. Esto soluciona los conflictos de ordenación cuando se mezclan productos con un 20% de descuento con productos que no tienen promoción (`null`), asegurando que estos últimos siempre queden al final de la lista de forma determinista.

## 🧪 Cómo probar esto
1.  Desplegar el `FiltersMenu` e interactuar con los chips de categorías. La lista debe reaccionar en milisegundos.
2.  Alternar entre ordenación por "Precio" y "Descuento". Verificar que el algoritmo `sortedWith` empuja los productos sin oferta al fondo.
3.  Simular una rotación de pantalla con el menú de filtros abierto para comprobar que el estado sobrevive gracias al DataStore y al `stateIn`.

## 💡 Próximos Pasos (Deuda Técnica)
Actualmente, el flujo de productos (`uiState`) depende de una invocación manual `loadProducts()` en el bloque `init`. El siguiente paso a nivel arquitectónico será eliminar este trabajo imperativo y transformar ese `combine` utilizando `.stateIn()` directamente, logrando que el 100% de los estados del ViewModel sean puramente declarativos.

.old
This pull request enhances the product list filtering and sorting functionality by centralizing filter state management in the `SettingsRepository` and updating the UI and business logic to use these centralized states. The changes improve maintainability and enable more dynamic, responsive filtering and sorting of products, including support for "in stock only" and discount-based sorting.

**Domain and State Management Improvements:**

* The `GetProductsUseCase` now receives `SettingsRepository` as a dependency and uses its `inStockOnly` property to filter products, ensuring only in-stock products are shown when this filter is active. [[1]](diffhunk://#diff-9b24b8e2e94469d564ab8a76a352248fe7dbe07f0925f8b042f08bc1e88e1825R6) [[2]](diffhunk://#diff-9b24b8e2e94469d564ab8a76a352248fe7dbe07f0925f8b042f08bc1e88e1825L14-R35)
* The `ProductListViewModel` now uses `SettingsRepository` for all filter and sort state, including `filtersVisible`, `selectedCategory`, and `sortOption`, replacing local state and making filter state observable and reactive.

**Product Filtering and Sorting Logic:**

* The UI state is now built by combining flows from product data and filter/sort settings, allowing dynamic updates when any filter or sort option changes. Sorting by discount now works correctly, and discount and price sorting logic is encapsulated in helper functions.
* The "Descuento" (discount) filter chip in the UI now correctly triggers sorting by discount instead of resetting sorting.

**UI/UX Improvements:**

* The visibility of filters in the UI is now managed via `SettingsRepository`, ensuring consistent filter state across the app.

These changes collectively make the product list screen more robust, maintainable, and responsive to user filter and sort preferences.

- Update `GetProductsUseCase` to inject `SettingsRepository` and filter products based on the `inStockOnly` preference.
- Refactor `ProductListViewModel` to reactively combine product data with category and sort settings from `SettingsRepository`.
- Implement sorting logic in `ProductListViewModel` for price (ascending/descending) and discount percentage.
- Migrate `filtersVisible` state in `ProductListViewModel` to use `SettingsRepository` for persistence.
- Fix a bug in `FiltersMenu` component where the discount sort option was incorrectly resetting to `SortOption.NONE`.
- Clean up unused imports and whitespace in `ProductListScreen`.