### PR TITLE
Implement Settings screen and update navigation logic

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/components/MarketTopAppBar.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/components/MarketTopAppBar.kt
@@ -1,0 +1,51 @@
+package com.amrubio27.cursotestingandroid.core.presentation.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MarketTopAppBar(
+    modifier: Modifier = Modifier,
+    onBackSelected: () -> Unit,
+    title: String
+) {
+    TopAppBar(
+        modifier = modifier,
+        title = {
+            Text(
+                title,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+        },
+        navigationIcon = {
+            IconButton(
+                onClick = {
+                    onBackSelected()
+                }
+            ) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Back",
+                    tint = MaterialTheme.colorScheme.onSurface
+                )
+            }
+        },
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            navigationIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+        )
+    )
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/navigation/NavGraph.kt
@@ -10,19 +10,22 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
 import com.amrubio27.cursotestingandroid.productlist.presentation.ProductListScreen
+import com.amrubio27.cursotestingandroid.settings.presentation.SettingsScreen
 
 @Composable
 fun NavGraph() {
     val backStack: NavBackStack<NavKey> = rememberNavBackStack(Screen.ProductList)
     val entries: (NavKey) -> NavEntry<NavKey> = entryProvider<NavKey> {
         entry<Screen.ProductList> {
-            ProductListScreen()
+            ProductListScreen(
+                navigateToSettings = { backStack.add(Screen.Setting) }
+            )
         }
         entry<Screen.Cart> {
             Text("Cart", fontSize = 30.sp)
         }
         entry<Screen.Setting> {
-            Text("Setting", fontSize = 30.sp)
+            SettingsScreen(onBack = { backStack.removeLastOrNull() })
         }
         entry<Screen.ProductDetail> {
             Text("ProductDetail", fontSize = 30.sp)

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreen.kt
@@ -37,7 +37,8 @@ import com.amrubio27.cursotestingandroid.productlist.presentation.components.Pro
 @Composable
 fun ProductListScreen(
     modifier: Modifier = Modifier,
-    productListViewModel: ProductListViewModel = hiltViewModel()
+    productListViewModel: ProductListViewModel = hiltViewModel(),
+    navigateToSettings: () -> Unit
 ) {
     val uiState by productListViewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -59,6 +60,7 @@ fun ProductListScreen(
             HomeTopAppBar(
                 filtersVisible = filtersVisible,
                 onFilterSelected = { showFilter -> productListViewModel.setFilterVisible(showFilter) },
+                onSettingsSelected = { navigateToSettings() }
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/HomeTopAppBar.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/HomeTopAppBar.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 fun HomeTopAppBar(
     modifier: Modifier = Modifier,
     filtersVisible: Boolean = true,
-    onFilterSelected: (Boolean) -> Unit = {},
+    onFilterSelected: (Boolean) -> Unit,
     onSettingsSelected: () -> Unit = {}
 ) {
     TopAppBar(

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreen.kt
@@ -1,0 +1,208 @@
+package com.amrubio27.cursotestingandroid.settings.presentation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.amrubio27.cursotestingandroid.core.presentation.components.MarketTopAppBar
+
+@Preview
+@Composable
+fun SettingsScreen(
+    onBack: () -> Unit = {}
+) {
+
+    Scaffold(
+        topBar = {
+            MarketTopAppBar(
+                title = "Ajustes", onBackSelected = { onBack() })
+        }) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
+            ) {
+                Column(
+                    Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Info,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(24.dp)
+                        )
+
+                        Text(
+                            "Filtros y visualización",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            fontWeight = FontWeight.Bold
+                        )
+
+                    }
+                    HorizontalDivider()
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Text(
+                                "Solo productos en Stock",
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.Medium
+                            )
+                            Text(
+                                "Muestra únicamente productos disponibles",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+
+                    HorizontalDivider()
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Text(
+                                "Mostrar impuestos incluídos",
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.Medium
+                            )
+                            Text(
+                                "Incluir impuestos de los precios mostrados",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+
+                        Switch(
+                            checked = true,
+                            onCheckedChange = {}
+                        )
+                    }
+                }
+            }
+
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
+            ) {
+                Column(
+                    Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.DarkMode,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(24.dp)
+                        )
+
+                        Text(
+                            "Apariencia",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            fontWeight = FontWeight.Bold
+                        )
+
+                    }
+                    HorizontalDivider()
+
+
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Text(
+                            "Tema de la aplicación",
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.Medium
+                        )
+                        Text(
+                            "Elige entre modo claro, oscuro o seguir el sistema",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        SingleChoiceSegmentedButtonRow(
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            SegmentedButton(
+                                shape = SegmentedButtonDefaults.itemShape(0, 3),
+                                onClick = { },
+                                selected = false,
+                                label = { Text("Sistema") }
+                            )
+                            SegmentedButton(
+                                shape = SegmentedButtonDefaults.itemShape(1, 3),
+                                onClick = { },
+                                selected = false,
+                                label = { Text("Claro") }
+                            )
+                            SegmentedButton(
+                                shape = SegmentedButtonDefaults.itemShape(2, 3),
+                                onClick = { },
+                                selected = false,
+                                label = { Text("Oscuro") }
+                            )
+                        }
+                    }
+
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request introduces a new Settings screen to the application and integrates navigation to it from the product list. It also adds a reusable top app bar component and updates existing components to support the new navigation flow and UI structure.

**New Feature: Settings Screen**
- Adds a new `SettingsScreen` composable with UI for appearance and filter options, including segmented buttons for theme selection and switches for toggling settings.

**Navigation Updates**
- Updates `NavGraph` to support navigation to the new settings screen from the product list, and enables back navigation from the settings screen.
- Modifies `ProductListScreen` to accept a `navigateToSettings` lambda, which is triggered when the settings button is selected. [[1]](diffhunk://#diff-7eefad4153d025cf84ca2f696ddca1bd49d94f87e8c239eb7fc8d79dc2ed3a25L40-R41) [[2]](diffhunk://#diff-7eefad4153d025cf84ca2f696ddca1bd49d94f87e8c239eb7fc8d79dc2ed3a25R63)

**UI Components**
- Adds a new reusable `MarketTopAppBar` composable for consistent top app bar styling across screens, including a back button.
- Updates `HomeTopAppBar` to require an explicit `onFilterSelected` callback and support an `onSettingsSelected` callback for navigation.- Create `MarketTopAppBar` as a reusable component with back navigation support.
- Implement `SettingsScreen` with UI sections for "Filtros y visualización" (Stock and Tax toggles) and "Apariencia" (Theme selection).
- Update `NavGraph` to include the `SettingsScreen` and handle back-stack navigation.
- Integrate settings navigation into `ProductListScreen` via `HomeTopAppBar`.
- Refactor `HomeTopAppBar` to expose the settings selection callback.