### PR TITLE
Integrate theme configuration logic and handle dynamic theme switching

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/MainActivity.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/MainActivity.kt
@@ -4,39 +4,38 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.activity.viewModels
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.amrubio27.cursotestingandroid.core.domain.model.ThemeMode
 import com.amrubio27.cursotestingandroid.core.presentation.navigation.NavGraph
 import com.amrubio27.cursotestingandroid.ui.theme.CursoTestingAndroidTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    private val mainViewModel: MainViewModel by viewModels()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            CursoTestingAndroidTheme {
+            val themeMode by mainViewModel.themeMode.collectAsStateWithLifecycle(
+                initialValue = ThemeMode.SYSTEM
+            )
+
+            val darkTheme = when (themeMode) {
+                ThemeMode.SYSTEM -> isSystemInDarkTheme()
+                ThemeMode.LIGHT -> false
+                ThemeMode.DARK -> true
+
+            }
+
+            CursoTestingAndroidTheme(
+                darkTheme = darkTheme
+            ) {
                 NavGraph()
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    CursoTestingAndroidTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/MainViewModel.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/MainViewModel.kt
@@ -1,0 +1,24 @@
+package com.amrubio27.cursotestingandroid
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.amrubio27.cursotestingandroid.core.domain.model.ThemeMode
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.SettingsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    settingsRepository: SettingsRepository
+) : ViewModel() {
+
+    val themeMode: Flow<ThemeMode> = settingsRepository.themeMode
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = ThemeMode.SYSTEM
+        )
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreen.kt
@@ -196,27 +196,25 @@ fun SettingsScreen(
                             SegmentedButton(
                                 shape = SegmentedButtonDefaults.itemShape(0, 3),
                                 onClick = { settingsViewModel.setThemeMode(ThemeMode.SYSTEM) },
-                                selected = false,
+                                selected = uiState.themeMode == ThemeMode.SYSTEM,
                                 label = { Text("Sistema") }
                             )
                             SegmentedButton(
                                 shape = SegmentedButtonDefaults.itemShape(1, 3),
                                 onClick = { settingsViewModel.setThemeMode(ThemeMode.LIGHT) },
-                                selected = false,
+                                selected = uiState.themeMode == ThemeMode.LIGHT,
                                 label = { Text("Claro") }
                             )
                             SegmentedButton(
                                 shape = SegmentedButtonDefaults.itemShape(2, 3),
                                 onClick = { settingsViewModel.setThemeMode(ThemeMode.DARK) },
-                                selected = false,
+                                selected = uiState.themeMode == ThemeMode.DARK,
                                 label = { Text("Oscuro") }
                             )
                         }
                     }
-
                 }
             }
         }
     }
-
 }


### PR DESCRIPTION
This pull request introduces dynamic theme switching based on user preference and system settings. The main changes include connecting the app's theme to a new `MainViewModel` that observes the selected theme mode, updating the UI to reflect the current theme choice, and ensuring the theme selection buttons in the settings screen properly indicate the active mode.

**Theme management and UI integration:**

* Implemented a new `MainViewModel` using Hilt for dependency injection, which exposes a `themeMode` Flow that tracks the user's theme preference from the `SettingsRepository` (`MainViewModel.kt`).
* Updated `MainActivity` to observe `themeMode` from `MainViewModel` and apply the corresponding dark or light theme dynamically using `CursoTestingAndroidTheme`. Removed unused composables and imports for clarity (`MainActivity.kt`).

**Settings screen improvements:**

* Modified the theme selection buttons in `SettingsScreen` so that the correct button is visually marked as selected based on the current `themeMode`, providing accurate feedback to the user (`SettingsScreen.kt`).- Implement `MainViewModel` to expose `themeMode` from `SettingsRepository` as a state flow.
- Update `MainActivity` to collect `themeMode` and dynamically apply light, dark, or system default themes to `CursoTestingAndroidTheme`.
- Update `SettingsScreen` to correctly reflect the selected theme mode in the `SingleChoiceSegmentedButtonRow` based on the UI state.
- Remove unused `Greeting` composable and preview from `MainActivity`.