### PR TITLE
Implement Add to Cart logic and fix stock filter in settings

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.BottomAppBar
+import androidx.compose.material3.BottomAppBarDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -36,6 +38,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.amrubio27.cursotestingandroid.R
 import com.amrubio27.cursotestingandroid.core.presentation.components.MarketTopAppBar
+import com.amrubio27.cursotestingandroid.detail.presentation.components.AddToCartButton
 import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductPromotion
 
 @Composable
@@ -56,9 +59,17 @@ fun ProductDetailScreen(
         MarketTopAppBar(
             title = uiState.item?.product?.name.orEmpty(), onBackSelected = { onBack() })
     }, bottomBar = {
-        /*AddToCartButton(
-            product = uiState.item?.product, isLoading = uiState.isLoading
-        ) { productDetailViewModel.addToCart() }*/
+        BottomAppBar(
+            windowInsets = BottomAppBarDefaults.windowInsets
+        ) {
+            AddToCartButton(
+                modifier = Modifier.weight(1f),
+                product = uiState.item?.product,
+                isLoading = uiState.isLoading
+            ) {
+                productDetailViewModel.addToCart()
+            }
+        }
     }, snackbarHost = { SnackbarHost(snackbarHostState) }) { paddingValues ->
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/components/AddToCartButton.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/components/AddToCartButton.kt
@@ -1,0 +1,23 @@
+package com.amrubio27.cursotestingandroid.detail.presentation.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.amrubio27.cursotestingandroid.productlist.domain.model.Product
+
+@Composable
+fun AddToCartButton(
+    modifier: Modifier = Modifier,
+    product: Product?,
+    isLoading: Boolean,
+    addToCart: () -> Unit
+) {
+
+    product?.let {
+        if (it.stock > 0) {
+            AddToCartButtonWithStock(modifier, it, isLoading, addToCart)
+        } else {
+            AddToCartButtonNoStock(modifier)
+        }
+    }
+
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/components/AddToCartButtonNoStock.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/components/AddToCartButtonNoStock.kt
@@ -1,0 +1,48 @@
+package com.amrubio27.cursotestingandroid.detail.presentation.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun AddToCartButtonNoStock(modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.fillMaxWidth(), shadowElevation = 8.dp, tonalElevation = 2.dp
+    ) {
+        Box(Modifier.padding(16.dp)) {
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = {},
+                enabled = false,
+                shape = RoundedCornerShape(12.dp),
+                colors = ButtonDefaults.buttonColors(disabledContainerColor = MaterialTheme.colorScheme.errorContainer)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Warning,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    "Sin stock disponible", fontWeight = FontWeight.Bold
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/components/AddToCartButtonWithStock.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/components/AddToCartButtonWithStock.kt
@@ -1,0 +1,54 @@
+package com.amrubio27.cursotestingandroid.detail.presentation.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.amrubio27.cursotestingandroid.productlist.domain.model.Product
+
+@Composable
+fun AddToCartButtonWithStock(
+    modifier: Modifier = Modifier, product: Product, isLoading: Boolean, addToCart: () -> Unit
+) {
+    Surface(
+        modifier = modifier
+            .fillMaxWidth(),
+        shadowElevation = 8.dp,
+        tonalElevation = 2.dp
+    ) {
+        Box(Modifier.padding(16.dp)) {
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { addToCart() },
+                enabled = !isLoading,
+                shape = RoundedCornerShape(12.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.ShoppingCart,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    "Agregar al carrito", fontWeight = FontWeight.Bold
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreen.kt
@@ -108,7 +108,7 @@ fun SettingsScreen(
                         }
 
                         Switch(
-                            checked = true,
+                            checked = uiState.inStockOnly,
                             onCheckedChange = { newState ->
                                 settingsViewModel.setInStockOnly(newState)
                             }


### PR DESCRIPTION
This pull request refactors and improves the "Add to Cart" functionality on the product detail screen. The main change is the introduction of a modular and state-aware "Add to Cart" button, which adapts its appearance and behavior based on product stock availability. The bottom bar now uses Material3's `BottomAppBar` for a more modern look and better integration with Compose standards.

**Product Detail Screen UI Improvements:**

* Replaced the previous bottom bar with Material3's `BottomAppBar`, and integrated the new `AddToCartButton` as its main action. This button now stretches to fill the available width, providing a more polished and consistent user experience.
* Updated imports in `ProductDetailScreen.kt` to include new Material3 components and the new `AddToCartButton` component. [[1]](diffhunk://#diff-d430fec67fea543216380d4d77bd033fac098a9d63c3a66d0d23194323f2f165R13-R14) [[2]](diffhunk://#diff-d430fec67fea543216380d4d77bd033fac098a9d63c3a66d0d23194323f2f165R41)

**Add to Cart Button Refactor:**

* Added a new composable `AddToCartButton` in `components/AddToCartButton.kt` that conditionally displays either a "with stock" or "no stock" button based on product availability.
* Implemented `AddToCartButtonWithStock` in `components/AddToCartButtonWithStock.kt`, displaying an enabled button with a shopping cart icon when the product is in stock.
* Implemented `AddToCartButtonNoStock` in `components/AddToCartButtonNoStock.kt`, displaying a disabled button with a warning icon and an appropriate message when out of stock.

**Settings Screen Minor Fix:**

* Fixed the "In Stock Only" switch in `SettingsScreen` to correctly reflect the state from `uiState.inStockOnly` instead of being hardcoded to `true`.…ilter

- Integrate `AddToCartButton` into `ProductDetailScreen` bottom bar, supporting conditional rendering based on stock availability.
- Create `AddToCartButtonWithStock` to handle active "Add to Cart" interactions with primary styling.
- Create `AddToCartButtonNoStock` to display a disabled state with a warning icon when products are out of stock.
- Fix state binding for the "In stock only" switch in `SettingsScreen` to correctly reflect the `uiState`.