### PR TITLE
Display cart item count badge in product list top bar

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.amrubio27.cursotestingandroid.cart.presentation.CartUiState
+import com.amrubio27.cursotestingandroid.cart.presentation.CartViewModel
 import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductWithPromotion
 import com.amrubio27.cursotestingandroid.productlist.presentation.components.FiltersMenu
 import com.amrubio27.cursotestingandroid.productlist.presentation.components.HomeTopAppBar
@@ -37,12 +39,14 @@ import com.amrubio27.cursotestingandroid.productlist.presentation.components.Pro
 @Composable
 fun ProductListScreen(
     modifier: Modifier = Modifier,
+    cartViewModel: CartViewModel = hiltViewModel(),
     productListViewModel: ProductListViewModel = hiltViewModel(),
     navigateToSettings: () -> Unit,
     navigateToProductDetail: (String) -> Unit,
     navigateToCart: () -> Unit
 ) {
     val uiState by productListViewModel.uiState.collectAsStateWithLifecycle()
+    val cartUiState by cartViewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val filtersVisible by productListViewModel.filtersVisible.collectAsStateWithLifecycle()
 
@@ -56,6 +60,16 @@ fun ProductListScreen(
         }
     }
 
+    val cartItemCount = remember(cartUiState) {
+        when (val state = cartUiState) {
+            is CartUiState.Success -> {
+                state.cartItems.sumOf { it.cartItem.quantity }
+            }
+
+            else -> 0
+        }
+    }
+
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -63,7 +77,8 @@ fun ProductListScreen(
                 filtersVisible = filtersVisible,
                 onFilterSelected = { showFilter -> productListViewModel.setFilterVisible(showFilter) },
                 onSettingsSelected = { navigateToSettings() },
-                onCartSelected = { navigateToCart() }
+                onCartSelected = { navigateToCart() },
+                cartItemCount = cartItemCount
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/HomeTopAppBar.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/HomeTopAppBar.kt
@@ -1,9 +1,12 @@
 package com.amrubio27.cursotestingandroid.productlist.presentation.components
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -14,6 +17,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
+import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -22,7 +26,8 @@ fun HomeTopAppBar(
     filtersVisible: Boolean = true,
     onFilterSelected: (Boolean) -> Unit,
     onSettingsSelected: () -> Unit = {},
-    onCartSelected: () -> Unit
+    onCartSelected: () -> Unit,
+    cartItemCount: Int
 ) {
     TopAppBar(
         title = {
@@ -55,14 +60,24 @@ fun HomeTopAppBar(
                     tint = MaterialTheme.colorScheme.onPrimaryContainer
                 )
             }
-            IconButton(
-                onClick = { onCartSelected() }
-            ) {
-                Icon(
-                    imageVector = Icons.Default.ShoppingCart,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer
-                )
+            BadgedBox(modifier = Modifier.padding(end = 4.dp), badge = {
+                if (cartItemCount > 0) {
+                    Badge {
+                        Text(
+                            if (cartItemCount > 99) "99+" else cartItemCount.toString(),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = Bold
+                        )
+                    }
+                }
+            }) {
+                IconButton(onClick = { onCartSelected() }) {
+                    Icon(
+                        imageVector = Icons.Default.ShoppingCart,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
             }
         },
         modifier = modifier


### PR DESCRIPTION
This pull request enhances the user interface by displaying a badge with the current cart item count on the shopping cart icon in the `HomeTopAppBar`. The count is dynamically calculated based on the cart's state and updates automatically. The most important changes are grouped below:

**Integration of Cart State into Product List Screen:**

* Injected `CartViewModel` into `ProductListScreen` and collected its `uiState` to access cart information. [[1]](diffhunk://#diff-7eefad4153d025cf84ca2f696ddca1bd49d94f87e8c239eb7fc8d79dc2ed3a25R32-R33) [[2]](diffhunk://#diff-7eefad4153d025cf84ca2f696ddca1bd49d94f87e8c239eb7fc8d79dc2ed3a25R42-R49)
* Calculated the total number of items in the cart by summing the quantities from `CartUiState.Success`, defaulting to 0 otherwise.

**UI Updates to Display Cart Item Count:**

* Updated the `HomeTopAppBar` composable to accept a new `cartItemCount` parameter, passing it from `ProductListScreen`. [[1]](diffhunk://#diff-7f1c670924c506b26f6581881c3dd7ebb02d9a30eb30ff0f74d6819b59ba6450L25-R30) [[2]](diffhunk://#diff-7eefad4153d025cf84ca2f696ddca1bd49d94f87e8c239eb7fc8d79dc2ed3a25R63-R81)
* Used `BadgedBox` and `Badge` to show the item count on the cart icon, displaying "99+" if the count exceeds 99, and only showing the badge when the count is greater than 0.
* Added required imports for badge and layout functionality in `HomeTopAppBar.kt`. [[1]](diffhunk://#diff-7f1c670924c506b26f6581881c3dd7ebb02d9a30eb30ff0f74d6819b59ba6450R3-R9) [[2]](diffhunk://#diff-7f1c670924c506b26f6581881c3dd7ebb02d9a30eb30ff0f74d6819b59ba6450R20)- Integrate `CartViewModel` into `ProductListScreen` to observe and collect the current cart state.
- Calculate the total quantity of items in the cart when `CartUiState` is successful.
- Update `HomeTopAppBar` to accept a `cartItemCount` parameter and display a dynamic badge.
- Implement a `BadgedBox` around the cart icon that displays the item count or "99+" for quantities exceeding 99.