### PR TITLE
Implement GetCartItemsWithPromotionsUseCase and refactor CartViewModel

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/cart/domain/usecase/GetCartWithPromotionsUseCase.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/cart/domain/usecase/GetCartWithPromotionsUseCase.kt
@@ -1,0 +1,49 @@
+package com.amrubio27.cursotestingandroid.cart.domain.usecase
+
+import com.amrubio27.cursotestingandroid.cart.domain.ex.activeAt
+import com.amrubio27.cursotestingandroid.cart.domain.repository.CartItemRepository
+import com.amrubio27.cursotestingandroid.cart.presentation.model.CartItemWithPromotion
+import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductWithPromotion
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.PromotionRepository
+import com.amrubio27.cursotestingandroid.productlist.domain.usecase.GetPromotionForProduct
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import java.time.Instant
+import javax.inject.Inject
+
+class GetCartItemsWithPromotionsUseCase @Inject constructor(
+    private val cartItemRepository: CartItemRepository,
+    private val productRepository: ProductRepository,
+    private val promotionRepository: PromotionRepository,
+    private val getPromotionForProduct: GetPromotionForProduct,
+) {
+
+    operator fun invoke(): Flow<List<CartItemWithPromotion>> {
+        return cartItemRepository.getCartItems().flatMapLatest { cartItems ->
+            val ids = cartItems.mapTo(mutableSetOf()) { it.productId }
+            if (ids.isEmpty()) {
+                flowOf(emptyList())
+            } else {
+                combine(
+                    productRepository.getProductsByIds(ids),
+                    promotionRepository.getActivePromotions()
+                ) { products, promotions ->
+                    val now = Instant.now()
+                    val activePromotions = promotions.activeAt(now)
+                    val productsById = products.associateBy { it.id }
+                    cartItems.mapNotNull { cartItem ->
+                        val product = productsById[cartItem.productId] ?: return@mapNotNull null
+                        val promotion = getPromotionForProduct(product, activePromotions)
+                        val productWithPromotion = ProductWithPromotion(product, promotion)
+                        CartItemWithPromotion(cartItem = cartItem, item = productWithPromotion)
+                    }
+                }
+            }
+        }
+    }
+
+
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/cart/presentation/CartViewModel.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/cart/presentation/CartViewModel.kt
@@ -3,10 +3,9 @@ package com.amrubio27.cursotestingandroid.cart.presentation
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.amrubio27.cursotestingandroid.cart.domain.repository.CartItemRepository
+import com.amrubio27.cursotestingandroid.cart.domain.usecase.GetCartItemsWithPromotionsUseCase
 import com.amrubio27.cursotestingandroid.cart.domain.usecase.GetCartSummaryUseCase
 import com.amrubio27.cursotestingandroid.cart.domain.usecase.UpdateCartItemUseCase
-import com.amrubio27.cursotestingandroid.cart.presentation.model.CartItemWithPromotion
-import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -17,9 +16,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -29,8 +26,7 @@ class CartViewModel @Inject constructor(
     private val cartItemRepository: CartItemRepository,
     private val getCartSummaryUseCase: GetCartSummaryUseCase,
     private val updateCartItemUseCase: UpdateCartItemUseCase,
-    private val productRepository: ProductRepository,
-    //private val getCartItemsWithPromotionsUseCase: GetCartItemsWithPromotionsUseCase
+    private val getCartItemsWithPromotionsUseCase: GetCartItemsWithPromotionsUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<CartUiState>(CartUiState.Loading)
@@ -49,39 +45,7 @@ class CartViewModel @Inject constructor(
         _uiState.value = CartUiState.Loading
         cartJob?.cancel()
 
-        cartJob = cartItemRepository.getCartItems().flatMapLatest { cartItems ->
-            val ids = cartItems.mapTo(mutableSetOf()) { it.productId }
-            if (ids.isEmpty()) {
-                getCartSummaryUseCase().map { summary ->
-                    _uiState.value = CartUiState.Success(
-                        summary = summary, cartItems = emptyList(), isLoading = false
-                    )
-                }
-            } else {
-                combine(
-                    productRepository.getProductsByIds(ids),
-                    getCartSummaryUseCase()
-                ) { products, summary ->
-                    val productsById = products.associateBy { it.id }
-                    val cartItemsWithProducts = cartItems.mapNotNull { cartItem ->
-                        val finalProduct =
-                            productsById[cartItem.productId] ?: return@mapNotNull null
-                        CartItemWithPromotion(
-                            product = finalProduct,
-                            cartItem = cartItem
-                        )
-                    }
-                    _uiState.value = CartUiState.Success(
-                        summary = summary, cartItems = cartItemsWithProducts, isLoading = false
-                    )
-                }
-            }
-
-        }.catch { e ->
-            _uiState.value = CartUiState.Error(e.message.orEmpty())
-        }.launchIn(viewModelScope)
-
-        /*cartJob = combine(
+        cartJob = combine(
             getCartItemsWithPromotionsUseCase(), getCartSummaryUseCase()
         ) { cartItemWithPromotion, summary ->
             _uiState.value = CartUiState.Success(
@@ -90,7 +54,7 @@ class CartViewModel @Inject constructor(
         }.catch { e ->
             _events.emit(CartEvent.ShowMessage(e.message.orEmpty()))
 
-        }.launchIn(viewModelScope)*/
+        }.launchIn(viewModelScope)
     }
 
 

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/cart/presentation/model/CartItemWthPromotion.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/cart/presentation/model/CartItemWthPromotion.kt
@@ -1,9 +1,9 @@
 package com.amrubio27.cursotestingandroid.cart.presentation.model
 
 import com.amrubio27.cursotestingandroid.cart.domain.model.CartItem
-import com.amrubio27.cursotestingandroid.productlist.domain.model.Product
+import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductWithPromotion
 
 data class CartItemWithPromotion(
     val cartItem: CartItem,
-    val product: Product
+    val item: ProductWithPromotion
 )


### PR DESCRIPTION
This pull request refactors how cart items and their associated promotions are retrieved and presented in the application. The main improvement is the introduction of the `GetCartItemsWithPromotionsUseCase` use case, which centralizes the logic for combining cart items with active promotions. The `CartViewModel` is updated to use this new use case, simplifying its code and improving maintainability. Additionally, the model for cart items with promotions is updated to better represent the relationship between products and promotions.

**Domain Logic Improvements:**
* Added a new use case `GetCartItemsWithPromotionsUseCase` that retrieves cart items along with their associated active promotions, combining data from cart, product, and promotion repositories. This encapsulates and centralizes the logic for determining active promotions for products in the cart.

**ViewModel Refactor:**
* Updated `CartViewModel` to use `GetCartItemsWithPromotionsUseCase` instead of manually combining cart items and products, resulting in cleaner and more maintainable code. Removed direct dependencies on `ProductRepository` and the previous manual logic for combining items and promotions. [[1]](diffhunk://#diff-903c8c9f9167af6e448d80d523ae11663d010caec53f5c8a4a6af98e0527f63bR6-L9) [[2]](diffhunk://#diff-903c8c9f9167af6e448d80d523ae11663d010caec53f5c8a4a6af98e0527f63bL20-L22) [[3]](diffhunk://#diff-903c8c9f9167af6e448d80d523ae11663d010caec53f5c8a4a6af98e0527f63bL32-R29) [[4]](diffhunk://#diff-903c8c9f9167af6e448d80d523ae11663d010caec53f5c8a4a6af98e0527f63bL52-R48) [[5]](diffhunk://#diff-903c8c9f9167af6e448d80d523ae11663d010caec53f5c8a4a6af98e0527f63bL93-R57)

**Model Update:**
* Changed the `CartItemWithPromotion` model to include a `ProductWithPromotion` instead of a separate product, ensuring that promotion data is always attached to the product when used in the cart.…tViewModel`

- Create `GetCartItemsWithPromotionsUseCase` to combine cart items, product data, and active promotions into `CartItemWithPromotion`.
- Update `CartItemWithPromotion` model to replace the raw `Product` with `ProductWithPromotion`.
- Refactor `CartViewModel` to use the new use case, simplifying UI state management and enabling promotion support in the cart.
- Remove deprecated manual product fetching logic and unused `ProductRepository` dependency from `CartViewModel`.
- Implement logic within the new use case to filter active promotions by the current timestamp and map products accordingly.