### PR TITLE
Add coroutines test dependency and organize test configurations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,7 +98,11 @@ dependencies {
     //Serialization
     implementation(libs.kotlinx.serialization.json)
 
+    //UnitTest
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+
+    //IntegrationTest
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,6 +73,7 @@ okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-i
 #Coroutines
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 
 #Lifecycle
 lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }


### PR DESCRIPTION
This pull request adds support for coroutine testing in the project by introducing the `kotlinx-coroutines-test` library to both the dependencies and the version catalog. This enables writing and running unit tests that involve coroutines.

Dependency updates for coroutine testing:

* Added `kotlinx-coroutines-test` to the version catalog in `gradle/libs.versions.toml` to manage its version alongside other coroutine libraries.
* Included `kotlinx-coroutines-test` as a test dependency in `app/build.gradle.kts`, allowing coroutine-based unit tests.- Add `kotlinx-coroutines-test` to `libs.versions.toml` and `app/build.gradle.kts`.
- Organize test dependencies in `build.gradle.kts` into UnitTest and IntegrationTest sections.