### PR TITLE
Implement fake repositories for cart and product domain testing

### DIFF
--- a/app/src/test/java/com/amrubio27/cursotestingandroid/cart/domain/usecase/AddToCartUseCaseTest.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/cart/domain/usecase/AddToCartUseCaseTest.kt
@@ -1,0 +1,5 @@
+package com.amrubio27.cursotestingandroid.cart.domain.usecase
+
+class AddToCartUseCaseTest {
+
+}

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakeCartItemRepository.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakeCartItemRepository.kt
@@ -1,0 +1,60 @@
+package com.amrubio27.cursotestingandroid.core.fakes
+
+import com.amrubio27.cursotestingandroid.cart.domain.model.CartItem
+import com.amrubio27.cursotestingandroid.cart.domain.repository.CartItemRepository
+import com.amrubio27.cursotestingandroid.core.domain.model.AppError
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class FakeCartItemRepository : CartItemRepository {
+    private val _cartItems = MutableStateFlow<List<CartItem>>(emptyList())
+
+    override fun getCartItems(): Flow<List<CartItem>> = _cartItems.asStateFlow()
+
+    override suspend fun addToCart(productId: String, quantity: Int) {
+        val currentItems = _cartItems.value.toMutableList()
+        val existingItem = currentItems.indexOfFirst { it.productId == productId }
+
+        if (existingItem >= 0) {
+            val item = currentItems[existingItem]
+            currentItems[existingItem] = item.copy(quantity = item.quantity + quantity)
+
+        } else {
+            currentItems.add(CartItem(productId, quantity))
+        }
+        _cartItems.value = currentItems
+    }
+
+    override suspend fun removeFromCart(productId: String) {
+        val currentItems = _cartItems.value.toMutableList()
+        val existingItem = currentItems.indexOfFirst { it.productId == productId }
+
+        if (existingItem >= 0) {
+            currentItems.removeAt(existingItem)
+            _cartItems.value = currentItems
+        } else {
+            throw AppError.NotFoundError
+        }
+    }
+
+    override suspend fun updateQuantity(productId: String, quantity: Int) {
+        val currentItems = _cartItems.value.toMutableList()
+        val existingItem = currentItems.indexOfFirst { it.productId == productId }
+
+        if (existingItem >= 0) {
+            currentItems[existingItem] = currentItems[existingItem].copy(quantity = quantity)
+            _cartItems.value = currentItems
+        } else {
+            throw AppError.NotFoundError
+        }
+    }
+
+    override suspend fun clearCart() {
+        _cartItems.value = emptyList()
+    }
+
+    override suspend fun getCartItemById(productId: String): CartItem? {
+        return _cartItems.value.find { it.productId == productId }
+    }
+}

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakeProductRepository.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakeProductRepository.kt
@@ -1,0 +1,31 @@
+package com.amrubio27.cursotestingandroid.core.fakes
+
+import com.amrubio27.cursotestingandroid.productlist.domain.model.Product
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+
+class FakeProductRepository : ProductRepository {
+    private val _products = MutableStateFlow<List<Product>>(emptyList())
+
+
+    override fun getProducts(): Flow<List<Product>> = _products.asStateFlow()
+
+    override fun getProductById(id: String): Flow<Product?> {
+        return _products.asStateFlow().map { products ->
+            products.find { it.id == id }
+        }
+    }
+
+    override suspend fun refreshProducts() {
+        //No effect
+    }
+
+    override fun getProductsByIds(ids: Set<String>): Flow<List<Product>> {
+        return _products.asStateFlow().map { products ->
+            products.filter { it.id in ids }
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces new fake repository implementations and a test class to support unit testing for cart and product features. These changes help facilitate isolated and reliable tests by providing in-memory, controllable data sources.

**Testing Infrastructure Additions:**

* Added `FakeCartItemRepository` implementing `CartItemRepository` with in-memory storage and support for all CRUD operations, including error simulation for missing items. (`app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakeCartItemRepository.kt`)
* Added `FakeProductRepository` implementing `ProductRepository` with in-memory product management and flow-based APIs for fetching and filtering products. (`app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakeProductRepository.kt`)

**Test Class Scaffolding:**

* Created an empty `AddToCartUseCaseTest` class as a starting point for unit tests of the add-to-cart feature. (`app/src/test/java/com/amrubio27/cursotestingandroid/cart/domain/usecase/AddToCartUseCaseTest.kt`)- Create `FakeProductRepository` to simulate product data retrieval and filtering by ID.
- Create `FakeCartItemRepository` to manage in-memory cart state, supporting operations like adding, removing, updating quantities, and clearing the cart.
- Add boilerplate for `AddToCartUseCaseTest` in the cart domain.