### PR TITLE
Given When Then: Implement unit tests for AddToCartUseCase and enhance FakeProductRepo…

### DIFF
--- a/app/src/test/java/com/amrubio27/cursotestingandroid/cart/domain/usecase/AddToCartUseCaseTest.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/cart/domain/usecase/AddToCartUseCaseTest.kt
@@ -1,5 +1,53 @@
 package com.amrubio27.cursotestingandroid.cart.domain.usecase
 
-class AddToCartUseCaseTest {
+import com.amrubio27.cursotestingandroid.core.domain.model.AppError
+import com.amrubio27.cursotestingandroid.core.fakes.FakeCartItemRepository
+import com.amrubio27.cursotestingandroid.core.fakes.FakeProductRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
 
+class AddToCartUseCaseTest {
+    @Test
+    fun zero_quantity_throws_QuantityMustBePositive() = runTest {
+        //Given
+        val cartItemRepository = FakeCartItemRepository()
+        val productRepository = FakeProductRepository().apply {
+            setProducts(emptyList())
+        }
+        val addToCartUseCase = AddToCartUseCase(cartItemRepository, productRepository)
+
+        //When
+        val exception = runCatching { addToCartUseCase("id", 0) }.exceptionOrNull()
+
+        //Then
+        assert(exception is AppError.Validation.QuantityMustBePositive)
+    }
+
+    @Test
+    fun negative_quantity_throws_QuantityMustBePositive() = runTest {
+        //Given
+        val cartItemRepository = FakeCartItemRepository()
+        val productRepository = FakeProductRepository()
+        val addToCartUseCase = AddToCartUseCase(cartItemRepository, productRepository)
+
+        //When
+        val exception = runCatching { addToCartUseCase("id", -2) }.exceptionOrNull()
+
+        //Then
+        assert(exception is AppError.Validation.QuantityMustBePositive)
+    }
+
+    @Test
+    fun non_existing_product_throws_NotFoundError() = runTest {
+        //Given
+        val cartItemRepository = FakeCartItemRepository()
+        val productRepository = FakeProductRepository()
+        val addToCartUseCase = AddToCartUseCase(cartItemRepository, productRepository)
+
+        //When
+        val exception = runCatching { addToCartUseCase("id", 1) }.exceptionOrNull()
+
+        //Then
+        assert(exception is AppError.NotFoundError)
+    }
 }

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakeProductRepository.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakeProductRepository.kt
@@ -10,6 +10,9 @@ import kotlinx.coroutines.flow.map
 class FakeProductRepository : ProductRepository {
     private val _products = MutableStateFlow<List<Product>>(emptyList())
 
+    fun setProducts(products: List<Product>) {
+        _products.value = products
+    }
 
     override fun getProducts(): Flow<List<Product>> = _products.asStateFlow()
 


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the `AddToCartUseCase` to verify error handling for invalid input and non-existent products. Additionally, it introduces a helper method to the `FakeProductRepository` to facilitate test setup.

**Testing improvements:**

* Added three new tests to `AddToCartUseCaseTest`:
  - Verifies that passing a zero or negative quantity to `AddToCartUseCase` throws a `QuantityMustBePositive` validation error.
  - Verifies that attempting to add a non-existent product throws a `NotFoundError`.

**Test utility enhancements:**

* Added a `setProducts` method to `FakeProductRepository` to easily set up product lists during testing.…sitory

- Add test cases to `AddToCartUseCaseTest` to verify validation logic for zero and negative quantities.
- Implement test case to ensure `NotFoundError` is thrown when attempting to add a non-existing product.
- Add `setProducts` helper method to `FakeProductRepository` to allow state manipulation during testing.