### PR TITLE
Refine GetPromotionForProduct logic and add unit tests

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetPromotionForProduct.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetPromotionForProduct.kt
@@ -9,30 +9,32 @@ import javax.inject.Inject
 
 class GetPromotionForProduct @Inject constructor() {
     operator fun invoke(product: Product, promotions: List<Promotion>): ProductPromotion? {
-
         val productPromos = promotions.filter {
             it.productIds.contains(product.id)
         }
 
-        val percentPromos = productPromos.filter {
-            it.type == PromotionType.PERCENT
-        }.maxByOrNull { it.value }
-
-        if (percentPromos != null) {
-            val percent = percentPromos.value.coerceIn(0.0, 100.0)
-            val discountPrice = product.price * (1 - percent / 100.0).roundTo2Decimals()
-            return ProductPromotion.Percent(percent = percent, discountedPrice = discountPrice)
-        }
-
-        val buyPayPromo = productPromos.firstOrNull() { it.type == PromotionType.BUY_X_PAY_Y }
+        val buyPayPromo = productPromos.firstOrNull { it.type == PromotionType.BUY_X_PAY_Y }
         if (buyPayPromo != null) {
             val buy = buyPayPromo.buyQuantity ?: return null
             val pay = buyPayPromo.value.toInt().coerceIn(0, buy)
 
             return ProductPromotion.BuyXPayY(
-                buy = buy, pay = pay, label = "{$buy}x{$pay}"
+                buy = buy,
+                pay = pay,
+                label = "${buy}x${pay}"
             )
         }
+
+        val percentPromo = productPromos.filter {
+            it.type == PromotionType.PERCENT
+        }.maxByOrNull { it.value }
+
+        if (percentPromo != null) {
+            val percent = percentPromo.value.coerceIn(0.0, 100.0)
+            val discountPrice = product.price * (1 - percent / 100.0).roundTo2Decimals()
+            return ProductPromotion.Percent(percent = percent, discountedPrice = discountPrice)
+        }
+
         return null
     }
 }

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/core/builders/PromotionBuilder.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/core/builders/PromotionBuilder.kt
@@ -1,0 +1,35 @@
+package com.amrubio27.cursotestingandroid.core.builders
+
+import com.amrubio27.cursotestingandroid.productlist.domain.model.Promotion
+import com.amrubio27.cursotestingandroid.productlist.domain.model.PromotionType
+import java.time.Instant
+
+class PromotionBuilder {
+    private var id: String = "promotion-1"
+    private var type: PromotionType = PromotionType.PERCENT
+    private var productsIds: List<String> = listOf("product-1")
+    private var value: Double = 10.0
+    private var buyQuantity: Int? = null
+    private var startTime: Instant = Instant.now().minusSeconds(3600)
+    private var endTime: Instant = Instant.now().plusSeconds(3600)
+
+    fun withId(id: String) = apply { this.id = id }
+    fun withType(type: PromotionType) = apply { this.type = type }
+    fun withProductsId(productsIds: List<String>) = apply { this.productsIds = productsIds }
+    fun withValue(value: Double) = apply { this.value = value }
+    fun withBuyQuantity(buyQuantity: Int?) = apply { this.buyQuantity = buyQuantity }
+    fun withStartTime(startTime: Instant) = apply { this.startTime = startTime }
+    fun withEndTime(endTime: Instant) = apply { this.endTime = endTime }
+
+    fun build() = Promotion(
+        id = id,
+        type = type,
+        productIds = productsIds,
+        value = value,
+        buyQuantity = buyQuantity,
+        startTime = startTime,
+        endTime = endTime
+    )
+}
+
+fun promotion(block: PromotionBuilder.() -> Unit = {}) = PromotionBuilder().apply(block).build()

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetPromotionForProductTest.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetPromotionForProductTest.kt
@@ -1,0 +1,136 @@
+package com.amrubio27.cursotestingandroid.productlist.domain.usecase
+
+import com.amrubio27.cursotestingandroid.core.builders.product
+import com.amrubio27.cursotestingandroid.core.builders.promotion
+import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductPromotion
+import com.amrubio27.cursotestingandroid.productlist.domain.model.PromotionType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GetPromotionForProductTest {
+    private val useCase = GetPromotionForProduct()
+
+    @Test
+    fun given_no_promotions_when_invoke_then_returns_null() {
+        //Given
+        val product = product()
+
+        //When
+        val response = useCase(product, emptyList())
+
+        //Then
+        assertNull(response)
+    }
+
+    @Test
+    fun given_percent_promotion_when_invoke_then_returns_discounted_price_rounds_to_2_decimals() {
+        //Given
+        val productId = "product-id"
+        val product = product {
+            withPrice(10.0)
+            withId(productId)
+        }
+        val promotion = promotion {
+            withType(PromotionType.PERCENT)
+            withProductsId(listOf(productId))
+            withValue(15.0)
+        }
+
+        //When
+        val response = useCase(product, listOf(promotion))
+
+        //Then
+        assertTrue(response is ProductPromotion.Percent)
+        response as ProductPromotion.Percent
+        assertEquals(8.5, response.discountedPrice, 0.001)
+        assertEquals(15.0, response.percent, 0.001)
+
+    }
+
+    @Test
+    fun given_buy_x_pay_y_and_percent_promotions_when_invoke_then_prioritizes_buy_x_pay_y() {
+        //Given
+        val productId = "product-id"
+        val product = product {
+            withPrice(10.0)
+            withId(productId)
+        }
+        val promotionPercent = promotion {
+            withType(PromotionType.PERCENT)
+            withProductsId(listOf(productId))
+            withValue(15.0)
+        }
+        val promotionBuyXPayY = promotion {
+            withType(PromotionType.BUY_X_PAY_Y)
+            withProductsId(listOf(productId))
+            withBuyQuantity(3)
+            withValue(2.0)
+
+        }
+
+        //When
+        val response = useCase(product, listOf(promotionPercent, promotionBuyXPayY))
+
+        //Then
+        assertTrue(response is ProductPromotion.BuyXPayY)
+        response as ProductPromotion.BuyXPayY
+        assertEquals(3, response.buy)
+        assertEquals(2, response.pay)
+        assertEquals("3x2", response.label)
+    }
+
+    @Test
+    fun given_multiple_promotions_when_invoke_then_returns_highest_discount() {
+        //Given
+        val productId = "product-id"
+        val product = product {
+            withPrice(10.0)
+            withId(productId)
+        }
+        val promotionLow = promotion {
+            withType(PromotionType.PERCENT)
+            withProductsId(listOf(productId))
+            withValue(5.0)
+        }
+        val promotionHigh = promotion {
+            withType(PromotionType.PERCENT)
+            withProductsId(listOf(productId))
+            withValue(50.0)
+        }
+
+        //When
+        val response = useCase(product, listOf(promotionLow, promotionHigh))
+
+        //Then
+        assertTrue(response is ProductPromotion.Percent)
+        assertEquals(50.0, (response as ProductPromotion.Percent).percent, 0.001)
+    }
+
+    @Test
+    fun given_buy_x_pay_y_without_buy_quantity_when_invoke_then_returns_null() {
+        //Given
+        val productId = "product-id"
+        val product = product {
+            withPrice(10.0)
+            withId(productId)
+        }
+        val promotionLow = promotion {
+            withType(PromotionType.PERCENT)
+            withProductsId(listOf(productId))
+            withValue(5.0)
+        }
+        val brokenBuyXPromotion = promotion {
+            withType(PromotionType.BUY_X_PAY_Y)
+            withProductsId(listOf(productId))
+            withBuyQuantity(null)
+        }
+        //When
+        val response = useCase(product, listOf(promotionLow, brokenBuyXPromotion))
+
+        //Then
+        assertNull(response)
+
+    }
+}


### PR DESCRIPTION
This pull request introduces unit tests for the `GetPromotionForProduct` use case and adds a test data builder for constructing `Promotion` objects. It also refactors the logic in `GetPromotionForProduct` to prioritize `BUY_X_PAY_Y` promotions over percent-based promotions and fixes a label formatting issue. The main changes are as follows:

**Testing improvements:**

* Added `GetPromotionForProductTest` with comprehensive test cases covering scenarios for percent promotions, buy X pay Y promotions, prioritization logic, highest discount selection, and edge cases.
* Introduced a `PromotionBuilder` and a `promotion` factory function to simplify and standardize the creation of `Promotion` objects in tests.

**Business logic and bug fixes:**

* Refactored `GetPromotionForProduct` to ensure `BUY_X_PAY_Y` promotions are prioritized over percent promotions and fixed the label formatting to use string interpolation (e.g., `"3x2"` instead of `"{3}x{2}"`).
* Adjusted the logic to return `null` if a `BUY_X_PAY_Y` promotion is missing the required `buyQuantity` field.