### PR TITLE
Implement unit tests for UpdateCartItemUseCase and enhance test utilities

### DIFF
--- a/app/src/test/java/com/amrubio27/cursotestingandroid/cart/domain/usecase/UpdateCartItemUseCaseTest.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/cart/domain/usecase/UpdateCartItemUseCaseTest.kt
@@ -1,0 +1,138 @@
+package com.amrubio27.cursotestingandroid.cart.domain.usecase
+
+import com.amrubio27.cursotestingandroid.core.builders.cartItem
+import com.amrubio27.cursotestingandroid.core.builders.product
+import com.amrubio27.cursotestingandroid.core.domain.model.AppError
+import com.amrubio27.cursotestingandroid.core.fakes.FakeCartItemRepository
+import com.amrubio27.cursotestingandroid.core.fakes.FakeProductRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UpdateCartItemUseCaseTest {
+    @Test
+    fun negative_quantity_throws_QuantityMustBePositive() = runTest {
+        //Given
+        val cartItemRepository = FakeCartItemRepository()
+        val productRepository = FakeProductRepository()
+        val useCase = UpdateCartItemUseCase(cartItemRepository, productRepository)
+
+        //When
+        val exception = runCatching { useCase("id", -2) }.exceptionOrNull()
+
+        //Then
+        assertTrue(exception is AppError.Validation.QuantityMustBePositive)
+    }
+
+    @Test
+    fun zero_quantity_remove_item_from_cart() = runTest {
+        //Given
+        val productId = "id-test-1"
+        val product = product {
+            withId(productId)
+            withStock(10)
+        }
+        val cartItemProduct = cartItem {
+            withProductId(productId)
+            withQuantity(1)
+        }
+
+        val cartItemRepository = FakeCartItemRepository().apply {
+            setCartItems(listOf(cartItemProduct))
+        }
+        val productRepository = FakeProductRepository().apply {
+            setProducts(listOf(product))
+        }
+        val useCase = UpdateCartItemUseCase(cartItemRepository, productRepository)
+
+        //When
+        useCase(productId, 0)
+
+        //Then
+        val items = cartItemRepository.getCartItems().first()
+        assertEquals(0, items.size)
+
+    }
+
+    @Test
+    fun non_existing_product_throws_NotFoundError() = runTest {
+        //Given
+        val productRepository = FakeProductRepository().apply {
+            setProducts(emptyList())
+        }
+        val cartItemRepository = FakeCartItemRepository()
+        val useCase = UpdateCartItemUseCase(cartItemRepository, productRepository)
+
+        //When
+        val exception = runCatching { useCase("id", 1) }.exceptionOrNull()
+
+        //Then
+        assert(exception is AppError.NotFoundError)
+    }
+
+    @Test
+    fun quantity_greater_than_stock_throws_insufficient_stock() = runTest {
+        //Given
+        val productId = "id-test-1"
+        val product = product {
+            withId(productId)
+            withStock(2)
+        }
+        val cartItemRepository = FakeCartItemRepository().apply {
+            setCartItems(
+                listOf(
+                cartItem {
+                    withProductId(productId)
+                    withQuantity(1)
+                }
+            ))
+        }
+        val productRepository = FakeProductRepository().apply {
+            setProducts(listOf(product))
+        }
+        val useCase = AddToCartUseCase(cartItemRepository, productRepository)
+
+        //when
+        val exception = runCatching {
+            useCase(productId, 5)
+        }.exceptionOrNull()
+
+        //then
+        assertTrue(exception is AppError.Validation.InsufficientStock)
+    }
+
+    @Test
+    fun given_valid_product_and_quantity_when_invoke_then_updates_cart_item() = runTest {
+        //Given
+        val productId = "id-test-1"
+        val product = product {
+            withId(productId)
+            withStock(20)
+        }
+        val cartItemRepository = FakeCartItemRepository().apply {
+            setCartItems(
+                listOf(
+                cartItem {
+                    withProductId(productId)
+                    withQuantity(1)
+                }
+            ))
+        }
+        val productRepository = FakeProductRepository().apply {
+            setProducts(listOf(product))
+        }
+        val useCase = UpdateCartItemUseCase(cartItemRepository, productRepository)
+
+        //When
+        useCase(productId, 5)
+
+        //Then
+        val items = cartItemRepository.getCartItems().first()
+        assertEquals(1, items.size)
+        assertEquals(5, items.first().quantity)
+
+    }
+
+}

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/core/builders/CartItemBuilder.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/core/builders/CartItemBuilder.kt
@@ -1,0 +1,15 @@
+package com.amrubio27.cursotestingandroid.core.builders
+
+import com.amrubio27.cursotestingandroid.cart.domain.model.CartItem
+
+class CartItemBuilder {
+    private var productId: String = "cart-item-1"
+    private var quantity: Int = 1
+
+    fun withProductId(productId: String) = apply { this.productId = productId }
+    fun withQuantity(quantity: Int) = apply { this.quantity = quantity }
+
+    fun build() = CartItem(productId, quantity)
+}
+
+fun cartItem(block: CartItemBuilder.() -> Unit = {}) = CartItemBuilder().apply(block).build()

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakeCartItemRepository.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakeCartItemRepository.kt
@@ -10,6 +10,10 @@ import kotlinx.coroutines.flow.asStateFlow
 class FakeCartItemRepository : CartItemRepository {
     private val _cartItems = MutableStateFlow<List<CartItem>>(emptyList())
 
+    fun setCartItems(cartItems: List<CartItem>) {
+        _cartItems.value = cartItems
+    }
+
     override fun getCartItems(): Flow<List<CartItem>> = _cartItems.asStateFlow()
 
     override suspend fun addToCart(productId: String, quantity: Int) {


### PR DESCRIPTION
This pull request introduces comprehensive unit tests for the `UpdateCartItemUseCase` and adds builder utilities to simplify test setup for cart items. It also enhances the `FakeCartItemRepository` to allow direct setting of cart items, making tests more flexible and easier to write.

### Testing improvements

* Added `UpdateCartItemUseCaseTest` with multiple test cases covering validation errors, removal of items, non-existent products, insufficient stock, and successful updates. This ensures the use case logic is thoroughly tested.

### Test utilities

* Introduced `CartItemBuilder` and the `cartItem` builder function to streamline the creation of `CartItem` objects in tests, improving readability and reducing boilerplate.
* Added a `setCartItems` method to `FakeCartItemRepository` to allow tests to pre-populate the repository with specific cart items.…ties

- Create `UpdateCartItemUseCaseTest` to verify business logic for updating cart items, including validation for negative quantities, insufficient stock, and product existence.
- Implement logic in tests to ensure providing a zero quantity correctly removes an item from the cart.
- Add `CartItemBuilder` to the core test builders to facilitate fluent creation of `CartItem` instances.
- Update `FakeCartItemRepository` with a `setCartItems` helper method to allow pre-configuring repository state during tests.