### PR TITLE
Add unit tests for active promotions and implement fake settings repository

### DIFF
--- a/app/src/test/java/com/amrubio27/cursotestingandroid/cart/domain/ex/PromotionsExtensionTest.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/cart/domain/ex/PromotionsExtensionTest.kt
@@ -1,0 +1,112 @@
+package com.amrubio27.cursotestingandroid.cart.domain.ex
+
+import com.amrubio27.cursotestingandroid.core.builders.promotion
+import com.amrubio27.cursotestingandroid.productlist.domain.model.Promotion
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.Instant
+
+class PromotionsExtensionTest {
+
+    private val now = Instant.parse("2026-04-14T11:00:00Z")
+
+    @Test
+    fun givenFuturePromotion_whenActiveAt_thenExclude() {
+
+        //Given
+        val futurePromotion = promotion {
+            withStartTime(now.plusSeconds(10))
+            withEndTime(now.plusSeconds(20))
+        }
+        val promotions = listOf(futurePromotion)
+
+        //When
+        val result = promotions.activeAt(now)
+
+        //Then
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun givenExpirePromotion_whenActiveAt_thenExclude() {
+
+        //Given
+        val expirePromotion = promotion {
+            withStartTime(now.minusSeconds(100))
+            withEndTime(now.minusSeconds(20))
+        }
+        val promotions = listOf(expirePromotion)
+
+        //When
+        val result = promotions.activeAt(now)
+
+        //Then
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun givenOnGoingPromotion_whenActiveAt_thenInclude() {
+
+        //Given
+        val activePromotion = promotion {
+            withStartTime(now.minusSeconds(1))
+            withEndTime(now.plusSeconds(1))
+        }
+        val promotions = listOf(activePromotion)
+
+        //When
+        val result = promotions.activeAt(now)
+
+        //Then
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun givenExactStartTimePromotion_whenActiveAt_thenInclude() {
+
+        //Given
+        val futurePromotion = promotion {
+            withStartTime(now)
+            withEndTime(now.plusSeconds(20))
+        }
+        val promotions = listOf(futurePromotion)
+
+        //When
+        val result = promotions.activeAt(now)
+
+        //Then
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun givenExactEndStartTimePromotion_whenActiveAt_thenInclude() {
+
+        //Given
+        val futurePromotion = promotion {
+            withStartTime(now.minusSeconds(100))
+            withEndTime(now)
+        }
+        val promotions = listOf(futurePromotion)
+
+        //When
+        val result = promotions.activeAt(now)
+
+        //Then
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun givenEmptyList_whenActiveAt_thenReturnEmpty() {
+
+        //Given
+        val promotions = emptyList<Promotion>()
+
+        //When
+        val result = promotions.activeAt(now)
+
+        //Then
+        assertEquals(0, result.size)
+    }
+
+
+}

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakeSettingsRepository.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakeSettingsRepository.kt
@@ -1,0 +1,44 @@
+package com.amrubio27.cursotestingandroid.core.fakes
+
+import com.amrubio27.cursotestingandroid.core.domain.model.ThemeMode
+import com.amrubio27.cursotestingandroid.productlist.domain.model.SortOption
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class FakeSettingsRepository : SettingsRepository {
+    private val _inStockOnly = MutableStateFlow(false)
+    private val _themeMode = MutableStateFlow<ThemeMode>(ThemeMode.SYSTEM)
+    private val _selectedCategory = MutableStateFlow<String?>(null)
+    private val _sortOption = MutableStateFlow(SortOption.NONE)
+    private val _filtersVisible = MutableStateFlow(true)
+
+
+    override val inStockOnly: Flow<Boolean> = _inStockOnly.asStateFlow()
+    override val themeMode: Flow<ThemeMode> = _themeMode.asStateFlow()
+    override val selectedCategory: Flow<String?> = _selectedCategory.asStateFlow()
+    override val sortOption: Flow<SortOption> = _sortOption.asStateFlow()
+    override val filtersVisible: Flow<Boolean> = _filtersVisible.asStateFlow()
+
+
+    override suspend fun setInStockOnly(value: Boolean) {
+        _inStockOnly.value = value
+    }
+
+    override suspend fun setThemeMode(value: ThemeMode) {
+        _themeMode.value = value
+    }
+
+    override suspend fun setSelectedCategory(value: String?) {
+        _selectedCategory.value = value
+    }
+
+    override suspend fun setFiltersVisible(value: Boolean) {
+        _filtersVisible.value = value
+    }
+
+    override suspend fun setSortOption(value: SortOption) {
+        _sortOption.value = value
+    }
+}


### PR DESCRIPTION
This pull request adds new test coverage and a fake repository implementation to support testing and development. The most important changes are the creation of a comprehensive test suite for promotion activation logic and the introduction of a `FakeSettingsRepository` for use in tests.

**Testing improvements:**

* Added `PromotionsExtensionTest` to verify the behavior of the `activeAt` extension for promotions, covering scenarios such as future, expired, ongoing, and edge-case promotions, as well as empty lists.

**Test infrastructure:**

* Introduced `FakeSettingsRepository`, a fake implementation of the `SettingsRepository` interface, providing controllable in-memory state for all repository properties and setters, to facilitate reliable and isolated testing.