### PR TITLE
Introduce Clock abstraction and enhance GetProductsUseCase testing

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/core/data/util/SystemClock.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/core/data/util/SystemClock.kt
@@ -1,0 +1,9 @@
+package com.amrubio27.cursotestingandroid.core.data.util
+
+import com.amrubio27.cursotestingandroid.core.domain.util.Clock
+import java.time.Instant
+import javax.inject.Inject
+
+class SystemClock @Inject constructor() : Clock {
+    override fun now(): Instant = Instant.now()
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/core/domain/util/Clock.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/core/domain/util/Clock.kt
@@ -1,0 +1,7 @@
+package com.amrubio27.cursotestingandroid.core.domain.util
+
+import java.time.Instant
+
+interface Clock {
+    fun now(): Instant
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/di/DataModule.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/di/DataModule.kt
@@ -10,7 +10,9 @@ import com.amrubio27.cursotestingandroid.cart.data.repository.CartItemRepository
 import com.amrubio27.cursotestingandroid.cart.domain.repository.CartItemRepository
 import com.amrubio27.cursotestingandroid.core.data.coroutines.DefaultDispatchersProvider
 import com.amrubio27.cursotestingandroid.core.data.local.database.MiniMarketDatabase
+import com.amrubio27.cursotestingandroid.core.data.util.SystemClock
 import com.amrubio27.cursotestingandroid.core.domain.coroutines.DispatchersProvider
+import com.amrubio27.cursotestingandroid.core.domain.util.Clock
 import com.amrubio27.cursotestingandroid.productlist.data.local.database.dao.ProductDao
 import com.amrubio27.cursotestingandroid.productlist.data.local.database.dao.PromotionDao
 import com.amrubio27.cursotestingandroid.productlist.data.repository.ProductRepositoryImpl
@@ -94,6 +96,12 @@ object DataModule {
         cartItemRepositoryImpl: CartItemRepositoryImpl
     ): CartItemRepository {
         return cartItemRepositoryImpl
+    }
+
+    @Provides
+    @Singleton
+    fun provideClock(systemClock: SystemClock): Clock {
+        return systemClock
     }
 
 }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetProductsUseCase.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetProductsUseCase.kt
@@ -1,19 +1,20 @@
 package com.amrubio27.cursotestingandroid.productlist.domain.usecase
 
+import com.amrubio27.cursotestingandroid.core.domain.util.Clock
 import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductWithPromotion
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.PromotionRepository
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.SettingsRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import java.time.Instant
 import javax.inject.Inject
 
 class GetProductsUseCase @Inject constructor(
     private val productRepository: ProductRepository,
     private val promotionRepository: PromotionRepository,
     private val getPromotionForProduct: GetPromotionForProduct,
-    private val settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository,
+    private val clock: Clock
 ) {
     operator fun invoke(): Flow<List<ProductWithPromotion>> {
         return combine(
@@ -21,7 +22,7 @@ class GetProductsUseCase @Inject constructor(
             promotionRepository.getActivePromotions(),
             settingsRepository.inStockOnly
         ) { products, promotions, inStockOnly ->
-            val now = Instant.now()
+            val now = clock.now()
             val activePromotions = promotions.filter {
                 it.startTime.isBefore(now) && it.endTime.isAfter(now)
             }

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakePromotionRepository.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakePromotionRepository.kt
@@ -1,0 +1,22 @@
+package com.amrubio27.cursotestingandroid.core.fakes
+
+import com.amrubio27.cursotestingandroid.productlist.domain.model.Promotion
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.PromotionRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class FakePromotionRepository : PromotionRepository {
+    private val _promotions = MutableStateFlow<List<Promotion>>(emptyList())
+
+    fun setPromotions(promotions: List<Promotion>) {
+        _promotions.value = promotions
+    }
+
+    override fun getActivePromotions(): Flow<List<Promotion>> {
+        return _promotions.asStateFlow()
+    }
+
+    override suspend fun refreshPromotions() {
+    }
+}

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakeSystemClock.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakeSystemClock.kt
@@ -1,0 +1,18 @@
+package com.amrubio27.cursotestingandroid.core.fakes
+
+import com.amrubio27.cursotestingandroid.core.domain.util.Clock
+import java.time.Instant
+
+class FakeSystemClock() : Clock {
+    private var currentTime: Instant = Instant.now()
+
+    override fun now(): Instant = currentTime
+
+    fun advanceTimeBy(seconds: Long) {
+        currentTime = currentTime.plusSeconds(seconds)
+    }
+
+    fun setTime(instant: Instant) {
+        currentTime = instant
+    }
+}

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetProductsUseCaseTest.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetProductsUseCaseTest.kt
@@ -1,0 +1,135 @@
+package com.amrubio27.cursotestingandroid.productlist.domain.usecase
+
+import com.amrubio27.cursotestingandroid.core.builders.product
+import com.amrubio27.cursotestingandroid.core.builders.promotion
+import com.amrubio27.cursotestingandroid.core.fakes.FakeProductRepository
+import com.amrubio27.cursotestingandroid.core.fakes.FakePromotionRepository
+import com.amrubio27.cursotestingandroid.core.fakes.FakeSettingsRepository
+import com.amrubio27.cursotestingandroid.core.fakes.FakeSystemClock
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+class GetProductsUseCaseTest {
+    private fun useCase(
+        products: FakeProductRepository = FakeProductRepository(),
+        promos: FakePromotionRepository = FakePromotionRepository(),
+        settings: FakeSettingsRepository = FakeSettingsRepository(),
+        clock: FakeSystemClock = FakeSystemClock()
+
+    ) = GetProductsUseCase(products, promos, GetPromotionForProduct(), settings, clock)
+
+    @Test
+    fun `given promotion ending now when invoke then it should be included`() = runTest {
+        //given
+        val now = Instant.parse("2026-06-01T12:00:00Z")
+        val clock = FakeSystemClock().apply {
+            setTime(now)
+        }
+        val productId = "product-id"
+        val product = product {
+            withId(productId)
+        }
+        val promo = promotion {
+            withProductsId(listOf(productId))
+            withStartTime(now.minusSeconds(60))
+            withEndTime(now)
+        }
+
+        val productRepository = FakeProductRepository().apply {
+            setProducts(listOf(product))
+        }
+        val promotionRepository = FakePromotionRepository().apply {
+            setPromotions(listOf(promo))
+        }
+
+        //when
+        val result = useCase(
+            products = productRepository,
+            promos = promotionRepository,
+            clock = clock
+        ).invoke().first()
+
+        //then
+        assertNotNull(result.first())
+    }
+
+    @Test
+    fun `given active promotion when time advances then promotion should not be longer be returned`() =
+        runTest {
+            //given
+            val now = Instant.parse("2026-04-03T10:00:00Z")
+            val clock = FakeSystemClock().apply {
+                setTime(now)
+            }
+            val productId = "product-id"
+            val product = product {
+                withId(productId)
+            }
+            val promo = promotion {
+                withProductsId(listOf(productId))
+                withStartTime(now.minusSeconds(1))
+                withEndTime(now.plusSeconds(5))
+            }
+
+            val productRepository = FakeProductRepository().apply {
+                setProducts(listOf(product))
+            }
+            val promotionRepository = FakePromotionRepository().apply {
+                setPromotions(listOf(promo))
+            }
+
+            //when
+            val firstResult = useCase(
+                products = productRepository,
+                promos = promotionRepository,
+                clock = clock
+            ).invoke().first()
+
+            clock.advanceTimeBy(6)
+
+            val secondResult = useCase(
+                products = productRepository,
+                promos = promotionRepository,
+                clock = clock
+            ).invoke().first()
+
+            //then
+            assertNotNull(firstResult.first().promotion)
+            assertNull(secondResult.first().promotion)
+        }
+
+    @Test
+    fun `given inStock Only enabled when product goes out of stock then it should be filtered`() =
+        runTest {
+            val productId = "product-id"
+            val product = product {
+                withId(productId)
+                withStock(0)
+            }
+
+            val settings = FakeSettingsRepository().apply {
+                setInStockOnly(true)
+            }
+
+            val productRepository = FakeProductRepository().apply {
+                setProducts(listOf(product))
+            }
+
+            val myUseCase = useCase(
+                products = productRepository,
+                settings = settings
+            )
+
+            //when
+            val result = myUseCase.invoke().first()
+
+            //then
+            assertTrue(result.isEmpty())
+
+        }
+}


### PR DESCRIPTION

This pull request introduces a testable time abstraction to the codebase, enabling better control over time-dependent logic and improving testability, especially for features involving promotions and product availability. The main changes include the introduction of a `Clock` interface, its implementations for production and testing, refactoring of the `GetProductsUseCase` to use this abstraction, and the addition of new test utilities and tests.

**Time abstraction and dependency injection:**

- Introduced a `Clock` interface in `core.domain.util` and provided a production implementation `SystemClock` in `core.data.util`, allowing time retrieval to be injected and controlled. (`[[1]](diffhunk://#diff-5f990237057cffde89d50e60379d169cc13c768c0178ea586a1ba26ebad6c4bfR1-R7)`, `[[2]](diffhunk://#diff-d53f1f352334303068083fd077beaef6354a0c7e446d57b6a54656079f24929aR1-R9)`)
- Registered the `SystemClock` as the singleton provider for `Clock` in the dependency injection module (`DataModule`). (`[[1]](diffhunk://#diff-ef31b39b2f33ffe67829becffa7d051e40f55a65647c3b02720ec302f5f71b78R13-R15)`, `[[2]](diffhunk://#diff-ef31b39b2f33ffe67829becffa7d051e40f55a65647c3b02720ec302f5f71b78R101-R106)`)

**Refactoring for testability:**

- Refactored `GetProductsUseCase` to depend on the injected `Clock` instead of directly calling `Instant.now()`, making the time logic testable and consistent. (`[app/src/main/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetProductsUseCase.ktR3-R25](diffhunk://#diff-9b24b8e2e94469d564ab8a76a352248fe7dbe07f0925f8b042f08bc1e88e1825R3-R25)`)

**Testing utilities and tests:**

- Added a `FakeSystemClock` implementation for use in tests, enabling manual control and advancement of time. (`[app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakeSystemClock.ktR1-R18](diffhunk://#diff-bc34d93b064af26cf2fd12806e613e2c605a5c73e33f417c5418e00c323ab2fbR1-R18)`)
- Added a `FakePromotionRepository` for easier test setup and manipulation of promotion data. (`[app/src/test/java/com/amrubio27/cursotestingandroid/core/fakes/FakePromotionRepository.ktR1-R22](diffhunk://#diff-84b79da648e83300571e9f5142e5d2c7e4dd7a28824f877cd1888f8b00d79dc1R1-R22)`)
- Introduced comprehensive tests for `GetProductsUseCase`, covering promotion timing and stock filtering scenarios using the new `Clock` abstraction and fakes. (`[app/src/test/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetProductsUseCaseTest.ktR1-R135](diffhunk://#diff-d0affa8738c4aec2775e4f97e7e74df32a976f9dc2722cd96acb043284ca2515R1-R135)`)

- Define `Clock` interface in domain and `SystemClock` implementation in data layer.
- Refactor `GetProductsUseCase` to use the injected `Clock` instead of `Instant.now()` for better testability.
- Provide `Clock` binding via `DataModule` using Hilt.
- Implement `FakeSystemClock` and `FakePromotionRepository` for use in testing.
- Add comprehensive unit tests in `GetProductsUseCaseTest` covering time-based promotion logic and stock filtering.