### PR TITLE
Refactor GetCartWithPromotionsUseCase for testability and add unit tests

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/cart/domain/usecase/GetCartWithPromotionsUseCase.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/cart/domain/usecase/GetCartWithPromotionsUseCase.kt
@@ -3,15 +3,16 @@ package com.amrubio27.cursotestingandroid.cart.domain.usecase
 import com.amrubio27.cursotestingandroid.cart.domain.ex.activeAt
 import com.amrubio27.cursotestingandroid.cart.domain.repository.CartItemRepository
 import com.amrubio27.cursotestingandroid.cart.presentation.model.CartItemWithPromotion
+import com.amrubio27.cursotestingandroid.core.domain.util.Clock
 import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductWithPromotion
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.PromotionRepository
 import com.amrubio27.cursotestingandroid.productlist.domain.usecase.GetPromotionForProduct
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
-import java.time.Instant
 import javax.inject.Inject
 
 class GetCartItemsWithPromotionsUseCase @Inject constructor(
@@ -19,8 +20,10 @@ class GetCartItemsWithPromotionsUseCase @Inject constructor(
     private val productRepository: ProductRepository,
     private val promotionRepository: PromotionRepository,
     private val getPromotionForProduct: GetPromotionForProduct,
+    private val clock: Clock
 ) {
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     operator fun invoke(): Flow<List<CartItemWithPromotion>> {
         return cartItemRepository.getCartItems().flatMapLatest { cartItems ->
             val ids = cartItems.mapTo(mutableSetOf()) { it.productId }
@@ -31,7 +34,7 @@ class GetCartItemsWithPromotionsUseCase @Inject constructor(
                     productRepository.getProductsByIds(ids),
                     promotionRepository.getActivePromotions()
                 ) { products, promotions ->
-                    val now = Instant.now()
+                    val now = clock.now()
                     val activePromotions = promotions.activeAt(now)
                     val productsById = products.associateBy { it.id }
                     cartItems.mapNotNull { cartItem ->
@@ -44,6 +47,4 @@ class GetCartItemsWithPromotionsUseCase @Inject constructor(
             }
         }
     }
-
-
 }

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/cart/domain/usecase/GetCartItemsWithPromotionsUseCaseTest.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/cart/domain/usecase/GetCartItemsWithPromotionsUseCaseTest.kt
@@ -1,0 +1,166 @@
+package com.amrubio27.cursotestingandroid.cart.domain.usecase
+
+import com.amrubio27.cursotestingandroid.core.builders.cartItem
+import com.amrubio27.cursotestingandroid.core.builders.product
+import com.amrubio27.cursotestingandroid.core.builders.promotion
+import com.amrubio27.cursotestingandroid.core.fakes.FakeCartItemRepository
+import com.amrubio27.cursotestingandroid.core.fakes.FakeProductRepository
+import com.amrubio27.cursotestingandroid.core.fakes.FakePromotionRepository
+import com.amrubio27.cursotestingandroid.core.fakes.FakeSystemClock
+import com.amrubio27.cursotestingandroid.productlist.domain.usecase.GetPromotionForProduct
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+class GetCartItemsWithPromotionsUseCaseTest {
+
+    private val clock = FakeSystemClock().apply { setTime(Instant.parse("2026-04-03T10:00:00Z")) }
+
+    private fun useCase(
+        cart: FakeCartItemRepository = FakeCartItemRepository(),
+        products: FakeProductRepository = FakeProductRepository(),
+        promos: FakePromotionRepository = FakePromotionRepository(),
+        clock: FakeSystemClock = this.clock
+    ) = GetCartItemsWithPromotionsUseCase(
+        cart, products, promos, GetPromotionForProduct(), clock
+    )
+
+    @Test
+    fun `given empty cart when invokes then returns empty list`() = runTest {
+        val cart = FakeCartItemRepository().apply { setCartItems(emptyList()) }
+
+        val result = (useCase(cart = cart)()).first()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `given existing cart item with active promotion when invoke then returns item with promotion`() =
+        runTest {
+            val productId = "productID"
+            val product = product {
+                withId(productId)
+            }
+            val now = clock.now()
+            val promo = promotion {
+                withProductIds(listOf(productId))
+                withStartTime(now.minusSeconds(10))
+                withEndTime(now.plusSeconds(10))
+            }
+            val cartItem = cartItem {
+                withProductId(productId)
+                withQuantity(2)
+            }
+
+            val cart = FakeCartItemRepository().apply { setCartItems(listOf(cartItem)) }
+            val products = FakeProductRepository().apply { setProducts(listOf(product)) }
+            val promotions = FakePromotionRepository().apply { setPromotions(listOf(promo)) }
+
+            val result = useCase(cart = cart, products = products, promos = promotions)().first()
+
+            assertEquals(1, result.size)
+            assertNotNull(result.first().item.promotion)
+        }
+
+    @Test
+    fun `given cart item without matching product when invoke then skip item`() = runTest {
+        val cart = FakeCartItemRepository().apply {
+            setCartItems(listOf(cartItem { withProductId("ghost-id") }))
+        }
+        val products = FakeProductRepository().apply {
+            setProducts(listOf(product { withId("other-id") }))
+        }
+
+        val result = useCase(products = products, cart = cart)().first()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `given promotion ending exactly now when invoke then it must be include`() = runTest {
+        val now = clock.now()
+        val productId = "productID"
+        val product = product {
+            withId(productId)
+        }
+        val endingPromotion = promotion {
+            withProductIds(listOf(productId))
+            withStartTime(now.minusSeconds(100))
+            withEndTime(now)
+        }
+
+        val cart =
+            FakeCartItemRepository().apply { setCartItems(listOf(cartItem { withProductId(productId) })) }
+        val products = FakeProductRepository().apply { setProducts(listOf(product)) }
+        val promotions = FakePromotionRepository().apply { setPromotions(listOf(endingPromotion)) }
+
+        val result = useCase(cart = cart, promos = promotions, products = products)().first()
+
+        assertNotNull(result.first().item.promotion)
+    }
+
+    @Test
+    fun `given expired promotion when invoke then item remains but without promotion`() = runTest {
+        val now = clock.now()
+        val productId = "productID"
+        val product = product {
+            withId(productId)
+        }
+        val endPromotion = promotion {
+            withProductIds(listOf(productId))
+            withStartTime(now.minusSeconds(100))
+            withEndTime(now.minusSeconds(1))
+        }
+
+        val cart =
+            FakeCartItemRepository().apply { setCartItems(listOf(cartItem { withProductId(productId) })) }
+        val products = FakeProductRepository().apply { setProducts(listOf(product)) }
+        val promotions = FakePromotionRepository().apply { setPromotions(listOf(endPromotion)) }
+
+        val result = useCase(cart = cart, promos = promotions, products = products)().first()
+
+        assertNull(result.first().item.promotion)
+    }
+
+    @Test
+    fun `given active promotion when time advances then flow emits update list without promotion`() =
+        runTest {
+            val now = clock.now()
+            val productId = "productID"
+            val product = product {
+                withId(productId)
+            }
+            val promotion = promotion {
+                withProductIds(listOf(productId))
+                withStartTime(now.minusSeconds(100))
+                withEndTime(now.plusSeconds(5))
+            }
+
+            val cart =
+                FakeCartItemRepository().apply {
+                    setCartItems(listOf(cartItem {
+                        withProductId(
+                            productId
+                        )
+                    }))
+                }
+            val products = FakeProductRepository().apply { setProducts(listOf(product)) }
+            val promotions = FakePromotionRepository().apply { setPromotions(listOf(promotion)) }
+
+            val myUseCase = useCase(cart = cart, promos = promotions, products = products)()
+
+            val firstEmission = myUseCase.first()
+            assertNotNull(firstEmission.first().item.promotion)
+
+            clock.advanceTimeBy(6)
+
+            val secondEmission = myUseCase.first()
+            assertNull(secondEmission.first().item.promotion)
+        }
+
+}

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/core/builders/PromotionBuilder.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/core/builders/PromotionBuilder.kt
@@ -15,7 +15,7 @@ class PromotionBuilder {
 
     fun withId(id: String) = apply { this.id = id }
     fun withType(type: PromotionType) = apply { this.type = type }
-    fun withProductsId(productsIds: List<String>) = apply { this.productsIds = productsIds }
+    fun withProductIds(productsIds: List<String>) = apply { this.productsIds = productsIds }
     fun withValue(value: Double) = apply { this.value = value }
     fun withBuyQuantity(buyQuantity: Int?) = apply { this.buyQuantity = buyQuantity }
     fun withStartTime(startTime: Instant) = apply { this.startTime = startTime }

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetProductsUseCaseTest.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetProductsUseCaseTest.kt
@@ -35,7 +35,7 @@ class GetProductsUseCaseTest {
             withId(productId)
         }
         val promo = promotion {
-            withProductsId(listOf(productId))
+            withProductIds(listOf(productId))
             withStartTime(now.minusSeconds(60))
             withEndTime(now)
         }
@@ -71,7 +71,7 @@ class GetProductsUseCaseTest {
                 withId(productId)
             }
             val promo = promotion {
-                withProductsId(listOf(productId))
+                withProductIds(listOf(productId))
                 withStartTime(now.minusSeconds(1))
                 withEndTime(now.plusSeconds(5))
             }

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetPromotionForProductTest.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/productlist/domain/usecase/GetPromotionForProductTest.kt
@@ -34,7 +34,7 @@ class GetPromotionForProductTest {
         }
         val promotion = promotion {
             withType(PromotionType.PERCENT)
-            withProductsId(listOf(productId))
+            withProductIds(listOf(productId))
             withValue(15.0)
         }
 
@@ -59,12 +59,12 @@ class GetPromotionForProductTest {
         }
         val promotionPercent = promotion {
             withType(PromotionType.PERCENT)
-            withProductsId(listOf(productId))
+            withProductIds(listOf(productId))
             withValue(15.0)
         }
         val promotionBuyXPayY = promotion {
             withType(PromotionType.BUY_X_PAY_Y)
-            withProductsId(listOf(productId))
+            withProductIds(listOf(productId))
             withBuyQuantity(3)
             withValue(2.0)
 
@@ -91,12 +91,12 @@ class GetPromotionForProductTest {
         }
         val promotionLow = promotion {
             withType(PromotionType.PERCENT)
-            withProductsId(listOf(productId))
+            withProductIds(listOf(productId))
             withValue(5.0)
         }
         val promotionHigh = promotion {
             withType(PromotionType.PERCENT)
-            withProductsId(listOf(productId))
+            withProductIds(listOf(productId))
             withValue(50.0)
         }
 
@@ -118,12 +118,12 @@ class GetPromotionForProductTest {
         }
         val promotionLow = promotion {
             withType(PromotionType.PERCENT)
-            withProductsId(listOf(productId))
+            withProductIds(listOf(productId))
             withValue(5.0)
         }
         val brokenBuyXPromotion = promotion {
             withType(PromotionType.BUY_X_PAY_Y)
-            withProductsId(listOf(productId))
+            withProductIds(listOf(productId))
             withBuyQuantity(null)
         }
         //When


### PR DESCRIPTION
This pull request introduces improvements to the cart domain logic and its testability, as well as standardizes the promotion builder API across the codebase. The main highlights are the injection of a `Clock` for better control over time-dependent logic, the addition of comprehensive unit tests for the cart use case, and the refactoring of the promotion builder for consistency.

**Cart Domain Improvements:**

* `GetCartItemsWithPromotionsUseCase` now accepts a `Clock` dependency, replacing direct usage of `Instant.now()`, which improves testability and allows for time to be controlled in tests. [[1]](diffhunk://#diff-dc8517c513bf0694beec35ddf70629d355b5bec0d7651d560b4354b248420879R6-R26) [[2]](diffhunk://#diff-dc8517c513bf0694beec35ddf70629d355b5bec0d7651d560b4354b248420879L34-R37)

**Testing Enhancements:**

* Added a new test class `GetCartItemsWithPromotionsUseCaseTest` that covers various scenarios for cart items and promotions, including time-based logic using a fake clock.

**Promotion Builder Refactor:**

* Renamed the builder method from `withProductsId` to `withProductIds` in `PromotionBuilder` for clarity and consistency.
* Updated all usages of the promotion builder in tests to use the new `withProductIds` method name. [[1]](diffhunk://#diff-d0affa8738c4aec2775e4f97e7e74df32a976f9dc2722cd96acb043284ca2515L38-R38) [[2]](diffhunk://#diff-d0affa8738c4aec2775e4f97e7e74df32a976f9dc2722cd96acb043284ca2515L74-R74) [[3]](diffhunk://#diff-d1a36664c3cf6561620fd20bc056e3a9e7105cdfdd8a21604c59f92514b0dcf4L37-R37) [[4]](diffhunk://#diff-d1a36664c3cf6561620fd20bc056e3a9e7105cdfdd8a21604c59f92514b0dcf4L62-R67) [[5]](diffhunk://#diff-d1a36664c3cf6561620fd20bc056e3a9e7105cdfdd8a21604c59f92514b0dcf4L94-R99) [[6]](diffhunk://#diff-d1a36664c3cf6561620fd20bc056e3a9e7105cdfdd8a21604c59f92514b0dcf4L121-R126)

- Inject `Clock` into `GetCartWithPromotionsUseCase` to replace static `Instant.now()` calls, enabling deterministic time-based testing.
- Add `@OptIn(ExperimentalCoroutinesApi::class)` to `GetCartWithPromotionsUseCase` to support `flatMapLatest`.
- Implement `GetCartItemsWithPromotionsUseCaseTest` covering empty carts, active/expired promotions, missing products, and boundary conditions for promotion validity.
- Update `FakeSystemClock` usage in tests to verify flow emissions when time advances.
- Rename `withProductsId` to `withProductIds` in `PromotionBuilder` and update all referencing tests for consistency.