### PR TITLE
Implement Clock injection for GetProductDetailWithPromotionUseCase and add unit tests

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/detail/domain/usecase/GetProductDetailWithPromotionUseCase.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/detail/domain/usecase/GetProductDetailWithPromotionUseCase.kt
@@ -1,18 +1,19 @@
 package com.amrubio27.cursotestingandroid.detail.domain.usecase
 
+import com.amrubio27.cursotestingandroid.core.domain.util.Clock
 import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductWithPromotion
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.PromotionRepository
 import com.amrubio27.cursotestingandroid.productlist.domain.usecase.GetPromotionForProduct
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import java.time.Instant
 import javax.inject.Inject
 
 class GetProductDetailWithPromotionUseCase @Inject constructor(
     private val productRepository: ProductRepository,
     private val promotionRepository: PromotionRepository,
-    private val getPromotionForProduct: GetPromotionForProduct
+    private val getPromotionForProduct: GetPromotionForProduct,
+    private val clock: Clock
 ) {
 
     operator fun invoke(productId: String): Flow<ProductWithPromotion?> {
@@ -20,7 +21,7 @@ class GetProductDetailWithPromotionUseCase @Inject constructor(
             productRepository.getProductById(productId),
             promotionRepository.getActivePromotions()
         ) { product, promotions ->
-            val now = Instant.now()
+            val now = clock.now()
             val activePromotions = promotions.filter {
                 it.startTime <= now && it.endTime >= now
             }

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/detail/domain/usecase/GetProductDetailWithPromotionUseCaseTest.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/detail/domain/usecase/GetProductDetailWithPromotionUseCaseTest.kt
@@ -1,0 +1,266 @@
+package com.amrubio27.cursotestingandroid.detail.domain.usecase
+
+import com.amrubio27.cursotestingandroid.core.builders.product
+import com.amrubio27.cursotestingandroid.core.builders.promotion
+import com.amrubio27.cursotestingandroid.core.fakes.FakeProductRepository
+import com.amrubio27.cursotestingandroid.core.fakes.FakePromotionRepository
+import com.amrubio27.cursotestingandroid.core.fakes.FakeSystemClock
+import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductPromotion
+import com.amrubio27.cursotestingandroid.productlist.domain.model.PromotionType
+import com.amrubio27.cursotestingandroid.productlist.domain.usecase.GetPromotionForProduct
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import java.time.Instant
+
+class GetProductDetailWithPromotionUseCaseTest {
+    private lateinit var productRepository: FakeProductRepository
+    private lateinit var promotionRepository: FakePromotionRepository
+    private lateinit var clock: FakeSystemClock
+
+    @Before
+    fun setup() {
+        productRepository = FakeProductRepository()
+        promotionRepository = FakePromotionRepository()
+        clock = FakeSystemClock().apply { setTime(Instant.parse("2026-04-03T10:00:00Z")) }
+    }
+
+    private fun useCase() = GetProductDetailWithPromotionUseCase(
+        productRepository,
+        promotionRepository,
+        GetPromotionForProduct(),
+        clock
+    )
+
+    // Si viene un producto con una id y una promo para él que me lo devuelva bien
+    @Test
+    fun `given product and active promotion when invoke then returns product with promotion`() =
+        runTest {
+            val now = clock.now()
+            val productId = "p1"
+            val product = product {
+                withId(productId)
+                withPrice(10.0)
+            }
+            val promotion = promotion {
+                withProductIds(listOf(productId))
+                withType(PromotionType.PERCENT)
+                withValue(20.0)
+                withStartTime(now.minusSeconds(10))
+                withEndTime(now.plusSeconds(10))
+            }
+
+            productRepository.setProducts(listOf(product))
+            promotionRepository.setPromotions(listOf(promotion))
+
+            val result = useCase().invoke(product.id).first()
+
+            // No viene null?
+            assertNotNull(result)
+            // Su id es la que le he pasado?
+            assertEquals(productId, result?.product?.id)
+            // existe la promo para el que le he pasado?
+            assertNotNull(result?.promotion)
+            // su promo es la que le puse?
+            assertTrue(result?.promotion is ProductPromotion.Percent)
+        }
+
+    // Si no hay promo me devuelve el producto normal sin promo
+    @Test
+    fun `given existing product and no promotions when invoke then emits product with null promotion`() =
+        runTest {
+            val productId = "p1"
+            val p1 = product { withId(productId); withPrice(100.0) }
+
+            productRepository.setProducts(listOf(p1))
+            promotionRepository.setPromotions(emptyList())
+
+            val result = useCase()(productId).first()
+
+            assertEquals(p1, result?.product)
+            assertNull(result?.promotion)
+        }
+
+    // Si hay dos promos, una caducada y otra bien, me aseguro que filtre bien
+    @Test
+    fun `given active and expired promotions when invoke then only active promotion is applied`() =
+        runTest {
+            val now = clock.now()
+            val productId = "p1"
+
+            val p1 = product {
+                withId(productId)
+                withPrice(100.0)
+            }
+
+            val activePromo = promotion {
+                withProductIds(listOf(productId))
+                withType(PromotionType.PERCENT)
+                withValue(20.0)
+                withStartTime(now.minusSeconds(10))
+                withEndTime(now.plusSeconds(10))
+            }
+
+            val expiredPromo = promotion {
+                withProductIds(listOf(productId))
+                withType(PromotionType.PERCENT)
+                withValue(50.0) // mayor descuento, pero caducada
+                withStartTime(now.minusSeconds(30))
+                withEndTime(now.minusSeconds(1))
+            }
+
+            productRepository.setProducts(listOf(p1))
+            promotionRepository.setPromotions(listOf(activePromo, expiredPromo))
+
+            val result = useCase()(productId).first()
+
+            assertNotNull(result)
+            assertTrue(result?.promotion is ProductPromotion.Percent)
+            assertEquals(20.0, (result?.promotion as ProductPromotion.Percent).percent, 0.001)
+        }
+
+    // Le paso un producto con promos expiradas me devuelve un producto normal
+    @Test
+    fun `given product and expired promotion when invoke then returns product with null promotion`() =
+        runTest {
+            val now = clock.now()
+            val productId = "p1"
+
+            val p1 = product {
+                withId(productId)
+                withPrice(100.0)
+            }
+
+            val expiredPromo = promotion {
+                withProductIds(listOf(productId))
+                withType(PromotionType.PERCENT)
+                withValue(15.0)
+                withStartTime(now.minusSeconds(20))
+                withEndTime(now.minusSeconds(5)) // Expiró hace 5 segundos
+            }
+
+            productRepository.setProducts(listOf(p1))
+            promotionRepository.setPromotions(listOf(expiredPromo))
+
+            val result = useCase()(productId).first()
+
+            assertNotNull(result)
+            assertEquals(productId, result?.product?.id)
+            assertNull("La promo es nula porque ya habia acabado", result?.promotion)
+        }
+
+    // Si no existe el id del producto que le llega deberia devolver null
+    @Test
+    fun `given non existent product when invoke then returns null`() = runTest {
+        // No añadimos nada a los repositorios porque no lo va a encontrar
+
+        val result = useCase()("p_not_found").first()
+
+        assertNull(result)
+    }
+
+    // Si pillas una promo pero se te caduca mientras tanto eres un pring... devuelve null la promo
+    @Test
+    fun `given promotion when time advances then promotion is no longer applied`() =
+        runTest {
+            val now = clock.now()
+            val productId = "p1"
+
+            val p1 = product {
+                withId(productId)
+                withPrice(100.0)
+            }
+
+            // La promo dura solo 5 segundos más
+            val promo = promotion {
+                withProductIds(listOf(productId))
+                withType(PromotionType.PERCENT)
+                withValue(10.0)
+                withStartTime(now.minusSeconds(10))
+                withEndTime(now.plusSeconds(5))
+            }
+
+            productRepository.setProducts(listOf(p1))
+            promotionRepository.setPromotions(listOf(promo))
+
+            val flow = useCase()(productId)
+
+            // Estado inicial: la promo está activa
+            assertNotNull(flow.first()?.promotion)
+
+            // Avanzamos el tiempo 6 segundos (la promo caduca)
+            clock.advanceTimeBy(6)
+
+            // Nuevo estado: la promo ya no debería aplicarse
+            assertNull(flow.first()?.promotion)
+        }
+
+    // Comprobando que los casos en los que se iguealen a Start y End
+    @Test
+    fun `given current time is exactly promotion start time when invoke then promotion is active`() =
+        runTest {
+            val now = clock.now()
+            val productId = "p1"
+
+            val p1 = product {
+                withId(productId)
+                withPrice(100.0)
+            }
+
+            // La promoción empieza EXACTAMENTE en el now
+            val promo = promotion {
+                withProductIds(listOf(productId))
+                withType(PromotionType.PERCENT)
+                withValue(20.0)
+                withStartTime(now)
+                withEndTime(now.plusSeconds(10))
+            }
+
+            productRepository.setProducts(listOf(p1))
+            promotionRepository.setPromotions(listOf(promo))
+
+            val result = useCase()(productId).first()
+
+            assertNotNull(
+                "La promo empieza exactamente en el now",
+                result?.promotion
+            )
+        }
+
+    @Test
+    fun `given current time is exactly promotion end time when invoke then promotion is still active`() =
+        runTest {
+            val now = clock.now()
+            val productId = "p1"
+
+            val p1 = product {
+                withId(productId)
+                withPrice(100.0)
+            }
+
+            // La promoción termina EXACTAMENTE en el 'now' actual
+            val promo = promotion {
+                withProductIds(listOf(productId))
+                withType(PromotionType.PERCENT)
+                withValue(20.0)
+                withStartTime(now.minusSeconds(10))
+                withEndTime(now)
+            }
+
+            productRepository.setProducts(listOf(p1))
+            promotionRepository.setPromotions(listOf(promo))
+
+            val result = useCase()(productId).first()
+
+            assertNotNull(
+                "Promotion todavía está activa exactamente en el endTime",
+                result?.promotion
+            )
+        }
+
+}


### PR DESCRIPTION
This pull request refactors how the current time is handled in the `GetProductDetailWithPromotionUseCase` and adds a comprehensive test suite for it. The main goal is to improve testability and reliability by injecting a `Clock` dependency instead of using the system time directly. This enables precise control over time in tests, ensuring consistent and predictable results.

Key changes:

**Dependency Injection & Time Handling:**

* Updated `GetProductDetailWithPromotionUseCase` to use a `Clock` dependency for retrieving the current time instead of directly calling `Instant.now()`. This makes the use case more testable and decouples it from the system clock.

**Testing Improvements:**

* Added a new test class `GetProductDetailWithPromotionUseCaseTest` with extensive unit tests covering various scenarios, including active promotions, expired promotions, edge cases for promotion start and end times, and time advancement. The tests use a `FakeSystemClock` to simulate time changes.…ests

- Inject `Clock` into `GetProductDetailWithPromotionUseCase` to allow for predictable time-based testing of active promotions.
- Replace `Instant.now()` with `clock.now()` in the use case logic to determine promotion validity.
- Add comprehensive unit tests for `GetProductDetailWithPromotionUseCase` covering:
    - Successful retrieval of a product with an active promotion.
    - Products with no promotions or only expired promotions.
    - Filtering between active and expired promotions.
    - Behavior when current time is exactly at the promotion start or end boundary.
    - Dynamic time advancement using a fake clock to verify promotion expiration.
    - Handling of non-existent product IDs.