### PR TITLE
Add MainDispatcherRule to properly test ViewModels 

### DIFF
--- a/app/src/test/java/com/amrubio27/cursotestingandroid/core/MainDispatcherRule.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/core/MainDispatcherRule.kt
@@ -1,0 +1,25 @@
+package com.amrubio27.cursotestingandroid.core
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    val scheduler: TestCoroutineScheduler = TestCoroutineScheduler(),
+    private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(scheduler)
+) : TestWatcher() {
+    override fun starting(description: Description?) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description?) {
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsViewModelTest.kt
@@ -1,0 +1,24 @@
+package com.amrubio27.cursotestingandroid.settings.presentation
+
+import com.amrubio27.cursotestingandroid.core.MainDispatcherRule
+import com.amrubio27.cursotestingandroid.core.fakes.FakeSettingsRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class SettingsViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun exampleTestCrash() = runTest {
+        val viewModel = SettingsViewModel(FakeSettingsRepository())
+
+        viewModel.setInStockOnly(true)
+
+        assertTrue(viewModel.uiState.value.inStockOnly)
+    }
+}


### PR DESCRIPTION
This pull request introduces unit testing support for coroutine-based code in the `settings` feature by adding a custom JUnit rule for managing the main dispatcher and an initial test for the `SettingsViewModel`. The changes help ensure that coroutine code can be tested reliably and that the `SettingsViewModel` behaves as expected when updating its state.

**Testing infrastructure improvements:**

* Added a new `MainDispatcherRule` class in `core` that sets and resets the main coroutine dispatcher for tests, enabling proper coroutine testing with JUnit.

**Settings feature tests:**

* Added a new test class `SettingsViewModelTest` that uses the `MainDispatcherRule` and provides an example test to verify that the `inStockOnly` property is updated correctly in the `SettingsViewModel`.

- Add `MainDispatcherRule` to manage `Dispatchers.Main` using `UnconfinedTestDispatcher` during unit tests.
- Implement `SettingsViewModelTest` to verify UI state updates, specifically for stock filter settings.
- Integrate `FakeSettingsRepository` to facilitate isolated testing of the view model.