### PR TITLE
Refactor SettingsViewModel to use stateIn and enhance unit tests

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsViewModel.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsViewModel.kt
@@ -5,10 +5,10 @@ import androidx.lifecycle.viewModelScope
 import com.amrubio27.cursotestingandroid.core.domain.model.ThemeMode
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -16,20 +16,17 @@ import javax.inject.Inject
 class SettingsViewModel @Inject constructor(
     private val settingsRepository: SettingsRepository
 ) : ViewModel() {
-    private val _uiState = MutableStateFlow<SettingsUiState>(SettingsUiState())
-    val uiState: StateFlow<SettingsUiState> = _uiState
 
-    init {
-        loadSettings()
-    }
-
-    private fun loadSettings() {
-        combine(
-            settingsRepository.inStockOnly, settingsRepository.themeMode
-        ) { inStockOnly, themeMode ->
-            _uiState.value = SettingsUiState(inStockOnly, themeMode)
-        }.launchIn(viewModelScope)
-    }
+    val uiState: StateFlow<SettingsUiState> = combine(
+        settingsRepository.inStockOnly,
+        settingsRepository.themeMode
+    ) { inStockOnly, themeMode ->
+        SettingsUiState(inStockOnly, themeMode)
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = SettingsUiState()
+    )
 
     fun setInStockOnly(newState: Boolean) {
         viewModelScope.launch {

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsViewModelTest.kt
@@ -3,16 +3,17 @@ package com.amrubio27.cursotestingandroid.settings.presentation
 import com.amrubio27.cursotestingandroid.core.MainDispatcherRule
 import com.amrubio27.cursotestingandroid.core.fakes.FakeSettingsRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class SettingsViewModelTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun exampleTestCrash() = runTest {
         val viewModel = SettingsViewModel(FakeSettingsRepository())
@@ -20,5 +21,16 @@ class SettingsViewModelTest {
         viewModel.setInStockOnly(true)
 
         assertTrue(viewModel.uiState.value.inStockOnly)
+    }
+
+    @Test
+    fun secondExample() = runTest(mainDispatcherRule.scheduler) {
+        val settingsRepository = FakeSettingsRepository().apply {
+            setInStockOnly(true)
+        }
+
+        val viewModel = SettingsViewModel(settingsRepository)
+        advanceUntilIdle()
+        assertTrue((viewModel.uiState.value.inStockOnly))
     }
 }


### PR DESCRIPTION
This pull request refactors the `SettingsViewModel` to improve state management and enhances test coverage for the settings feature. The most important changes are summarized below.

**State Management Refactor:**

* The `SettingsViewModel` now exposes `uiState` as a `StateFlow` directly derived from the repository using `combine` and `stateIn`, eliminating the manual `MutableStateFlow` and `loadSettings` initialization logic. This makes state updates more reactive and concise.

**Testing Improvements:**

* Added a new test, `secondExample`, in `SettingsViewModelTest` to verify that the `inStockOnly` state is correctly reflected in the view model when set in the repository. The test uses `advanceUntilIdle` to ensure all coroutines complete before assertion.
* Applied the `@ExperimentalCoroutinesApi` annotation at the class level in `SettingsViewModelTest` for improved clarity and coverage.

- Refactor `SettingsViewModel` to use `stateIn` for the `uiState` property instead of manual flow collection in `init`.
- Configure `uiState` with `SharingStarted.WhileSubscribed(5000)` and a default `SettingsUiState`.
- Update `SettingsViewModelTest` to include an additional test case verifying state updates using `advanceUntilIdle`.
- Move `@ExperimentalCoroutinesApi` annotation to the class level in `SettingsViewModelTest`.