### PR TITLE
Add unit tests for SettingsViewModel with Turbine integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,4 +111,5 @@ dependencies {
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
+    testImplementation(libs.turbine)
 }

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsViewModelTest.kt
@@ -1,9 +1,12 @@
 package com.amrubio27.cursotestingandroid.settings.presentation
 
+import app.cash.turbine.test
 import com.amrubio27.cursotestingandroid.core.MainDispatcherRule
+import com.amrubio27.cursotestingandroid.core.domain.model.ThemeMode
 import com.amrubio27.cursotestingandroid.core.fakes.FakeSettingsRepository
+import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -15,22 +18,81 @@ class SettingsViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     @Test
-    fun exampleTestCrash() = runTest {
-        val viewModel = SettingsViewModel(FakeSettingsRepository())
+    fun `GIVEN repository with values WHEN viewmodel is initialized THEN uistate is updated`() =
+        runTest(mainDispatcherRule.scheduler) {
+            val settingsRepository = FakeSettingsRepository().apply {
+                setInStockOnly(true)
+            }
 
-        viewModel.setInStockOnly(true)
+            val viewModel = SettingsViewModel(settingsRepository)
 
-        assertTrue(viewModel.uiState.value.inStockOnly)
-    }
-
-    @Test
-    fun secondExample() = runTest(mainDispatcherRule.scheduler) {
-        val settingsRepository = FakeSettingsRepository().apply {
-            setInStockOnly(true)
+            viewModel.uiState.test {
+                val state = awaitItem()
+                assertTrue(state.inStockOnly)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
 
-        val viewModel = SettingsViewModel(settingsRepository)
-        advanceUntilIdle()
-        assertTrue((viewModel.uiState.value.inStockOnly))
-    }
+    @Test
+    fun `given viewmodel when theme mode is changed then ui stated and repository are updated`() =
+        runTest(mainDispatcherRule.scheduler) {
+            //GIVEN
+            val settingsRepository = FakeSettingsRepository()
+            val viewModel = SettingsViewModel(settingsRepository)
+
+            viewModel.uiState.test {
+                awaitItem()
+
+                //WHEN
+                viewModel.setThemeMode(ThemeMode.DARK)
+
+                //THEN
+                val updateState = awaitItem()
+                assertEquals(ThemeMode.DARK, updateState.themeMode)
+
+                assertEquals(ThemeMode.DARK, settingsRepository.themeMode.first())
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given viewmodel when in stock only is changed then ui stated and repository are updated`() =
+        runTest(mainDispatcherRule.scheduler) {
+            //GIVEN
+            val settingsRepository = FakeSettingsRepository()
+            val viewModel = SettingsViewModel(settingsRepository)
+
+            viewModel.uiState.test {
+                awaitItem()
+
+                //WHEN
+                viewModel.setInStockOnly(true)
+
+                //THEN
+                val updateState = awaitItem()
+                assertEquals(true, updateState.inStockOnly)
+
+                assertEquals(true, settingsRepository.inStockOnly.first())
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given viewmodel when repository change externally when ui state update automatically`() =
+        runTest(mainDispatcherRule.scheduler) {
+            val settingsRepository = FakeSettingsRepository()
+            val viewModel = SettingsViewModel(settingsRepository)
+
+            viewModel.uiState.test {
+                awaitItem()
+
+                settingsRepository.setInStockOnly(true)
+
+                assertTrue(awaitItem().inStockOnly)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ retrofit = "3.0.0"
 okhttp = "5.3.2"
 coroutines = "1.10.2"
 ksp = "2.3.6"
+turbine = "1.2.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -82,6 +83,7 @@ androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lif
 
 #Mock
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 
 [plugins]


### PR DESCRIPTION
This pull request improves the unit tests for the `SettingsViewModel` by introducing more comprehensive test cases and utilizing the Turbine library for testing Kotlin Flows. It also adds the Turbine dependency to the project configuration files.

**Testing improvements:**

* Replaced basic tests in `SettingsViewModelTest.kt` with more descriptive and robust tests that verify UI state updates and repository synchronization for both theme mode and "in stock only" settings, including handling of external repository changes. The new tests use the Turbine library to assert Flow emissions.
* Added imports for Turbine and related dependencies in `SettingsViewModelTest.kt`.

**Dependency updates:**

* Added the Turbine library to the test dependencies in `app/build.gradle.kts`.
* Declared the Turbine version and library reference in `gradle/libs.versions.toml` for consistent dependency management. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR23) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR86)

- Add `turbine` dependency for testing asynchronous flows.
- Implement tests to verify `SettingsViewModel` initialization with repository values.
- Add test cases for updating `themeMode` and `inStockOnly` settings, ensuring both `uiState` and repository are correctly synchronized.
- Implement a test case to verify that external repository changes automatically trigger `uiState` updates.
- Remove obsolete example test cases from `SettingsViewModelTest`.

Usando turbineScope

```
@Test
    fun `GIVEN viewmodel WHEN mode is changed THEN ui stated and repository are updated`() =
        runTest {
            turbineScope {
                val settingsRepository = FakeSettingsRepository()
                val viewmodel = SettingsViewModel(settingsRepository)
                val state = viewmodel.uiState.testIn(this)
                state.awaitItem()

                viewmodel.onAction(SettingsAction.SetThemeMode(ThemeMode.DARK))

                val updateState = state.awaitItem()
                assertEquals(ThemeMode.DARK, updateState.themeMode)
                assertEquals(ThemeMode.DARK, settingsRepository.themeMode.first())
                state.cancelAndIgnoreRemainingEvents()
            }
        }
}
```