### PR TITLE
Refactor ProductListViewModel to use reactive StateFlow for UI state

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListViewModel.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListViewModel.kt
@@ -9,86 +9,61 @@ import com.amrubio27.cursotestingandroid.productlist.domain.repository.SettingsR
 import com.amrubio27.cursotestingandroid.productlist.domain.usecase.GetProductsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jakarta.inject.Inject
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 @HiltViewModel
 class ProductListViewModel @Inject constructor(
-    private val getProductsUseCase: GetProductsUseCase,
+    getProductsUseCase: GetProductsUseCase,
     private val settingsRepository: SettingsRepository
 ) : ViewModel() {
-    private val _uiState = MutableStateFlow<ProductListUiState>(ProductListUiState.Loading)
-    val uiState: StateFlow<ProductListUiState> = _uiState.asStateFlow()
+    val uiState: StateFlow<ProductListUiState> = combine(
+        getProductsUseCase(), settingsRepository.selectedCategory, settingsRepository.sortOption
+    ) { products, selectedCategory, sortOption ->
+        var filteredProducts = products
+        if (selectedCategory != null) {
+            filteredProducts = filteredProducts.filter { it.product.category == selectedCategory }
+        }
+
+        val sorted = when (sortOption) {
+            SortOption.NONE -> filteredProducts
+            SortOption.PRICE_ASC -> filteredProducts.sortedBy { effecticePrice(it) }
+            SortOption.PRICE_DESC -> filteredProducts.sortedByDescending { effecticePrice(it) }
+            SortOption.DISCOUNT -> filteredProducts.sortedWith(compareByDescending<ProductWithPromotion> {
+                effectiveDiscountPercent(it)
+            }.thenBy {
+                it.promotion == null
+            })
+        }
+
+        val categories = products.map { it.product.category }.distinct().sorted()
+
+        ProductListUiState.Success(
+            products = sorted,
+            categories = categories,
+            selectedCategory = selectedCategory,
+            sortOption = sortOption
+        ) as ProductListUiState
+    }.catch { exception: Throwable ->
+        emit(ProductListUiState.Error(exception.message.orEmpty()))
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = ProductListUiState.Loading
+    )
 
     private val _events = MutableSharedFlow<ProductListEvent>(extraBufferCapacity = 1)
     val events: SharedFlow<ProductListEvent> = _events
 
     val filtersVisible: StateFlow<Boolean> = settingsRepository.filtersVisible.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
-        initialValue = false
+        scope = viewModelScope, started = SharingStarted.WhileSubscribed(5000), initialValue = false
     )
-
-    private var productsJob: Job? = null
-
-    init {
-        loadProducts()
-    }
-
-    fun loadProducts() {
-        _uiState.value = ProductListUiState.Loading
-        productsJob?.cancel()
-        productsJob = combine(
-            getProductsUseCase(),
-            settingsRepository.selectedCategory,
-            settingsRepository.sortOption
-        ) { products, selectedCategory, sortOption ->
-            var filteredProducts = products
-            if (selectedCategory != null) {
-                filteredProducts =
-                    filteredProducts.filter { it.product.category == selectedCategory }
-            }
-
-            val sorted = when (sortOption) {
-                SortOption.NONE -> filteredProducts
-                SortOption.PRICE_ASC -> filteredProducts.sortedBy { effecticePrice(it) }
-                SortOption.PRICE_DESC -> filteredProducts.sortedByDescending { effecticePrice(it) }
-                SortOption.DISCOUNT ->
-                    //filteredProducts.sortedByDescending { effectiveDiscountPercent(it) }
-                    filteredProducts.sortedWith(
-                        compareByDescending<ProductWithPromotion> {
-                            effectiveDiscountPercent(it)
-                        }.thenBy {
-                            it.promotion == null
-                        }
-                    )
-            }
-
-            val categories = products.map { it.product.category }.distinct().sorted()
-
-            ProductListUiState.Success(
-                products = sorted,
-                categories = categories,
-                selectedCategory = selectedCategory,
-                sortOption = sortOption
-            )
-        }.onEach { state ->
-            _uiState.value = state
-        }.catch { exception: Throwable ->
-            _uiState.value = ProductListUiState.Error(exception.message.orEmpty())
-        }.launchIn(viewModelScope)
-    }
 
     fun setCategory(category: String?) {
         viewModelScope.launch {


### PR DESCRIPTION
This pull request refactors the `ProductListViewModel` to simplify state management and improve code clarity. The main change is replacing manual state handling with a reactive approach using `combine` and `stateIn`, which makes the code more concise and idiomatic for Kotlin coroutines and flows.

**Refactoring of UI State Management:**

* Replaced manual management of `_uiState`, `loadProducts()`, and related coroutine job handling with a single reactive `uiState` property that uses `combine` and `stateIn` to automatically update the UI state based on products, selected category, and sort option. This removes the need for explicit state updates and job cancellation. [[1]](diffhunk://#diff-b6f5340fe336eca2fb55d153b98eedd929b4b0b9d413c2313365ba5cf8361563L12-R42) [[2]](diffhunk://#diff-b6f5340fe336eca2fb55d153b98eedd929b4b0b9d413c2313365ba5cf8361563L85-R66)
* Updated error handling to emit `ProductListUiState.Error` directly inside the combined flow, ensuring errors are handled reactively.

**Code Simplification and Cleanup:**

* Removed unnecessary imports and the `productsJob` variable, as well as the now-obsolete `loadProducts()` method and manual coroutine management.
* Kept the events and filters visibility flows, but restructured them for clarity and consistency with the new state management approach.

- Replace manual `MutableStateFlow` management and `loadProducts` function with a `combine` operator chain.
- Convert `uiState` into a `StateFlow` using `stateIn` with a 5-second subscription timeout.
- Simplify state updates by deriving filtered and sorted product lists directly from `GetProductsUseCase` and `SettingsRepository` flows.
- Remove redundant `Job` tracking and explicit `init` block for loading products.
- Improve error handling within the flow using the `catch` operator to emit `ProductListUiState.Error`.