### PR TITLE
Stubs: Add error handling test for ProductListViewModel

### DIFF
--- a/app/src/test/java/com/amrubio27/cursotestingandroid/core/stubs/FailingProductRepositoryStub.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/core/stubs/FailingProductRepositoryStub.kt
@@ -1,0 +1,20 @@
+package com.amrubio27.cursotestingandroid.core.stubs
+
+import com.amrubio27.cursotestingandroid.productlist.domain.model.Product
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+
+class FailingProductRepositoryStub(
+    private val exception: Throwable
+) : ProductRepository {
+    override fun getProducts(): Flow<List<Product>> = flow { throw exception }
+
+    override fun getProductById(id: String): Flow<Product?> = flowOf()
+
+    override suspend fun refreshProducts() {}
+
+    override fun getProductsByIds(ids: Set<String>): Flow<List<Product>> = flowOf()
+
+}

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListViewModelTest.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListViewModelTest.kt
@@ -7,6 +7,7 @@ import com.amrubio27.cursotestingandroid.core.fakes.FakeProductRepository
 import com.amrubio27.cursotestingandroid.core.fakes.FakePromotionRepository
 import com.amrubio27.cursotestingandroid.core.fakes.FakeSettingsRepository
 import com.amrubio27.cursotestingandroid.core.fakes.FakeSystemClock
+import com.amrubio27.cursotestingandroid.core.stubs.FailingProductRepositoryStub
 import com.amrubio27.cursotestingandroid.productlist.domain.model.SortOption
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
 import com.amrubio27.cursotestingandroid.productlist.domain.usecase.GetProductsUseCase
@@ -104,6 +105,25 @@ class ProductListViewModelTest {
                 assertEquals(15.0, state.products[0].product.price, 0.0)
                 assertEquals(30.0, state.products[1].product.price, 0.0)
                 assertEquals(SortOption.PRICE_ASC, state.sortOption)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given repository error when loading products then emits error state`() =
+        runTest(mainDispatcherRule.scheduler) {
+
+            val failingRepository = FailingProductRepositoryStub(Exception("Prueba test"))
+
+
+            val viewModel = createViewModel(fakeProduct = failingRepository)
+
+            viewModel.uiState.test {
+                val state = awaitItem()
+
+                assertTrue(state is ProductListUiState.Error)
+                assertTrue((state as ProductListUiState.Error).message == "Prueba test")
 
                 cancelAndIgnoreRemainingEvents()
             }


### PR DESCRIPTION
This pull request adds improved error handling for the product list feature by introducing a stub repository that simulates failures and a corresponding unit test to verify error state emission in the ViewModel. The most important changes are:

**Testing infrastructure:**

* Added a new `FailingProductRepositoryStub` in `core.stubs`, which implements `ProductRepository` and throws a provided exception when `getProducts` is called. This allows for simulating repository errors in tests.

**Unit tests:**

* Updated imports in `ProductListViewModelTest.kt` to include the new `FailingProductRepositoryStub`.
* Added a test in `ProductListViewModelTest` that verifies the ViewModel emits an error state with the correct message when the repository throws an exception.

- Create `FailingProductRepositoryStub` to simulate repository exceptions during data flow.
- Add unit test in `ProductListViewModelTest` to verify that the UI state correctly transitions to `ProductListUiState.Error` when the product repository fails.