### PR TITLE
Using Mockk: Implement unit tests for ProductListViewModel with MockK

### DIFF
--- a/app/src/test/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListViewModelMockTest.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListViewModelMockTest.kt
@@ -1,0 +1,92 @@
+package com.amrubio27.cursotestingandroid.productlist.presentation
+
+import com.amrubio27.cursotestingandroid.core.MainDispatcherRule
+import com.amrubio27.cursotestingandroid.core.fakes.FakeProductRepository
+import com.amrubio27.cursotestingandroid.core.fakes.FakePromotionRepository
+import com.amrubio27.cursotestingandroid.core.fakes.FakeSettingsRepository
+import com.amrubio27.cursotestingandroid.core.fakes.FakeSystemClock
+import com.amrubio27.cursotestingandroid.productlist.domain.model.SortOption
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.SettingsRepository
+import com.amrubio27.cursotestingandroid.productlist.domain.usecase.GetProductsUseCase
+import com.amrubio27.cursotestingandroid.productlist.domain.usecase.GetPromotionForProduct
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+class ProductListViewModelMockTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val settingsRepository: SettingsRepository = mockk(relaxed = true) {
+        every { selectedCategory } returns flowOf(null)
+        every { sortOption } returns flowOf(SortOption.NONE)
+        every { inStockOnly } returns flowOf(false)
+        every { filtersVisible } returns flowOf(true)
+    }
+
+    private fun createViewModel(
+        fakeProduct: ProductRepository = FakeProductRepository(),
+        fakeSettings: FakeSettingsRepository = FakeSettingsRepository(),
+        fakePromotion: FakePromotionRepository = FakePromotionRepository(),
+        fakeClock: FakeSystemClock = FakeSystemClock()
+    ): ProductListViewModel {
+
+        val getProductUseCase = GetProductsUseCase(
+            fakeProduct, fakePromotion, GetPromotionForProduct(), fakeSettings, fakeClock
+        )
+
+        return ProductListViewModel(
+            getProductsUseCase = getProductUseCase, settingsRepository = settingsRepository
+        )
+    }
+
+    @Test
+    fun `given category when set category then delegates to settings repository`() =
+        runTest(mainDispatcherRule.scheduler) {
+
+            //GIVEN
+            val viewModel = createViewModel()
+            val category = "pasta"
+
+            //WHEN
+            viewModel.setCategory(category)
+
+            //THEN
+            coVerify(exactly = 1) { settingsRepository.setSelectedCategory(category) }
+
+        }
+
+    @Test
+    fun `given sort option when set sort option then delegates to settings repository`() =
+        runTest(mainDispatcherRule.scheduler) {
+            //GIVEN
+            val viewModel = createViewModel()
+            val option = SortOption.DISCOUNT
+
+            //WHEN
+            viewModel.setSortOption(option)
+
+            //THEN
+            coVerify(exactly = 1) { settingsRepository.setSortOption(option) }
+        }
+
+    @Test
+    fun `given filter visible when set filter visible then delegates to settings repository`() =
+        runTest(mainDispatcherRule.scheduler) {
+            //GIVEN
+            val viewModel = createViewModel()
+            val option = true
+
+            //WHEN
+            viewModel.setFilterVisible(option)
+
+            //THEN
+            coVerify(exactly = 1) { settingsRepository.setFiltersVisible(option) }
+        }
+}


### PR DESCRIPTION
This pull request adds a new unit test class for the `ProductListViewModel` to verify its interactions with the `SettingsRepository` using mocks. The tests ensure that the view model properly delegates certain actions to the repository.

New test coverage for `ProductListViewModel`:

* Added `ProductListViewModelMockTest` to test that `setCategory`, `setSortOption`, and `setFilterVisible` methods in `ProductListViewModel` correctly delegate to the corresponding methods in `SettingsRepository` using `coVerify` from MockK.
* Utilized a mocked `SettingsRepository` and provided fake implementations for other dependencies to isolate the tests to view model and repository interaction.
* Ensured coroutine-based testing by applying `MainDispatcherRule` and using `runTest` for all test cases.

- Create `ProductListViewModelMockTest` to verify interactions with `SettingsRepository`.
- Implement tests for `setCategory`, `setSortOption`, and `setFilterVisible` using `coVerify` to ensure delegation to the repository.
- Use a relaxed mock for `SettingsRepository` with default flow values for category, sorting, and visibility state.
- Integrate `MainDispatcherRule` and `runTest` for coroutine-based testing.