### PR TITLE
Implement unit tests for MainViewModel

### DIFF
--- a/app/src/test/java/com/amrubio27/cursotestingandroid/MainViewModelTest.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/MainViewModelTest.kt
@@ -1,0 +1,44 @@
+package com.amrubio27.cursotestingandroid
+
+import app.cash.turbine.test
+import com.amrubio27.cursotestingandroid.core.MainDispatcherRule
+import com.amrubio27.cursotestingandroid.core.domain.model.ThemeMode
+import com.amrubio27.cursotestingandroid.core.fakes.FakeSettingsRepository
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.SettingsRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class MainViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private fun createViewModel(fakeSettingsRepository: SettingsRepository = FakeSettingsRepository()) =
+        MainViewModel(fakeSettingsRepository)
+
+    @Test
+    fun `given repository with dark mode when initialized then emits dark theme mode`() =
+        runTest(mainDispatcherRule.scheduler) {
+            val fakeSettingsRepository =
+                FakeSettingsRepository().apply { setThemeMode(ThemeMode.DARK) }
+            val viewModel = createViewModel(fakeSettingsRepository)
+
+            viewModel.themeMode.test {
+                assertEquals(ThemeMode.DARK, awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given default repository when initialized then emits system theme mode`() =
+        runTest(mainDispatcherRule.scheduler) {
+            val viewModel = createViewModel()
+
+            viewModel.themeMode.test {
+                assertEquals(ThemeMode.SYSTEM, awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+}


### PR DESCRIPTION
This pull request adds a new test class to verify the behavior of the `MainViewModel` regarding theme mode selection. The tests ensure that the correct theme mode is emitted based on the repository's state.

**New tests for theme mode behavior:**

* Added `MainViewModelTest` to test the initialization of `MainViewModel` with different theme modes using a `FakeSettingsRepository`.
* Verified that the view model emits `ThemeMode.DARK` when the repository is set to dark mode.
* Verified that the view model emits `ThemeMode.SYSTEM` when using the default repository settings.

- Add `MainViewModelTest` using Turbine for Flow verification.
- Implement tests to verify `themeMode` emission based on `SettingsRepository` values.
- Test initialization with default system settings and explicit dark mode configuration.
- Integrate `MainDispatcherRule` and `FakeSettingsRepository` for test isolation.