### PR TITLE
Refactor ProductDetailViewModel for reactive UI state and update tests

### DIFF
--- a/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailViewModel.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailViewModel.kt
@@ -10,16 +10,18 @@ import com.amrubio27.cursotestingandroid.core.domain.model.AppError.NotFoundErro
 import com.amrubio27.cursotestingandroid.core.domain.model.AppError.UnknownError
 import com.amrubio27.cursotestingandroid.core.domain.model.AppError.Validation
 import com.amrubio27.cursotestingandroid.detail.domain.usecase.GetProductDetailWithPromotionUseCase
+import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductWithPromotion
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -29,31 +31,37 @@ class ProductDetailViewModel @Inject constructor(
     val addToCartUseCase: AddToCartUseCase
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow<ProductDetailUiState>(ProductDetailUiState())
-    val uiState: StateFlow<ProductDetailUiState> = _uiState.asStateFlow()
-
     private val _events = MutableSharedFlow<ProductDetailEvent>(extraBufferCapacity = 1)
     val events: SharedFlow<ProductDetailEvent> = _events
 
-    private var productJob: Job? = null
+    private val loadTrigger = MutableSharedFlow<String>(extraBufferCapacity = 1)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val uiState: StateFlow<ProductDetailUiState> = loadTrigger
+        .flatMapLatest { productId ->
+            getProductDetailWithPromotionUseCase(productId)
+                .map<ProductWithPromotion?, ProductDetailUiState> { product ->
+                    ProductDetailUiState(item = product, isLoading = false)
+                }
+                .onStart { emit(ProductDetailUiState(isLoading = true)) }
+                .catch { e ->
+                    val appError = if (e is AppError) e else AppError.UnknownError(e.message)
+                    handleError(appError)
+                    emit(ProductDetailUiState(item = null, isLoading = false))
+                }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = ProductDetailUiState(isLoading = true)
+        )
 
     fun loadProduct(productId: String) {
-        _uiState.value = _uiState.value.copy(isLoading = true)
-        productJob?.cancel()
-        productJob = getProductDetailWithPromotionUseCase(productId).onEach { product ->
-            _uiState.value = _uiState.value.copy(isLoading = false, item = product)
-        }.catch { e: Throwable ->
-            _uiState.value = _uiState.value.copy(isLoading = false)
-            if (e is AppError) {
-                handleError(e)
-            } else {
-                handleError(AppError.UnknownError(e.message))
-            }
-        }.launchIn(viewModelScope)
+        loadTrigger.tryEmit(productId)
     }
 
     fun addToCart() {
-        val product = _uiState.value.item?.product?.id ?: return
+        val product = uiState.value.item?.product?.id ?: return
         viewModelScope.launch {
             try {
                 addToCartUseCase(product)

--- a/app/src/test/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailViewModelTest.kt
+++ b/app/src/test/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailViewModelTest.kt
@@ -90,12 +90,19 @@ class ProductDetailViewModelTest {
             fakeProduct.setProducts(listOf(p))
             val viewModel = createViewModel()
 
-            viewModel.loadProduct("1")
+            viewModel.uiState.test {
+                awaitItem() // initial
+                viewModel.loadProduct("1")
+                val loaded = awaitItem()
+                assertEquals("1", loaded.item?.product?.id)
 
-            viewModel.events.test {
-                viewModel.addToCart()
-                val result = awaitItem()
-                assertEquals(ProductDetailEvent.SUCCESS_ADD_TO_CART, result)
+                viewModel.events.test {
+                    viewModel.addToCart()
+                    val result = awaitItem()
+                    assertEquals(ProductDetailEvent.SUCCESS_ADD_TO_CART, result)
+                    cancelAndIgnoreRemainingEvents()
+                }
+
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -107,15 +114,21 @@ class ProductDetailViewModelTest {
             fakeProduct.setProducts(listOf(p))
             val viewModel = createViewModel()
 
-            viewModel.loadProduct("1")
+            viewModel.uiState.test {
+                awaitItem() // initial
+                viewModel.loadProduct("1")
+                val loaded = awaitItem()
+                assertEquals("1", loaded.item?.product?.id)
 
-            viewModel.events.test {
-                viewModel.addToCart()
-                val result = awaitItem()
-                assertEquals(ProductDetailEvent.INSUFFICIENT_STOCK_ERROR, result)
+                viewModel.events.test {
+                    viewModel.addToCart()
+                    val result = awaitItem()
+                    assertEquals(ProductDetailEvent.INSUFFICIENT_STOCK_ERROR, result)
+                    cancelAndIgnoreRemainingEvents()
+                }
+
                 cancelAndIgnoreRemainingEvents()
             }
-
         }
 
 


### PR DESCRIPTION
This pull request refactors the `ProductDetailViewModel` to use a more reactive approach with Kotlin Flows, improving state management and testability. The main changes include replacing manual state handling and job management with flow operators, and updating tests to work with the new flow-based state.

**ViewModel Refactor and State Management:**

* Replaced manual use of `MutableStateFlow`, job cancellation, and direct state mutation in `ProductDetailViewModel` with a reactive approach using a `MutableSharedFlow` (`loadTrigger`) and flow operators (`flatMapLatest`, `map`, `onStart`, `catch`, `stateIn`). This ensures that loading product details is now fully reactive and automatically cancels previous requests if a new one arrives. (`app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailViewModel.kt`, [[1]](diffhunk://#diff-e6976745f65651d1bfae169936fc5466ee56dd9e32695b2957998afa63a47e2cR13-R24) [[2]](diffhunk://#diff-e6976745f65651d1bfae169936fc5466ee56dd9e32695b2957998afa63a47e2cL32-R64)

**Testing Updates:**

* Updated `ProductDetailViewModelTest` to collect from the `uiState` flow and assert state changes after triggering `loadProduct`, ensuring tests are compatible with the new flow-based state management. (`app/src/test/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailViewModelTest.kt`, [[1]](diffhunk://#diff-0919214587c0ea19d221514a6e92cb7eb455fa0c40502d14aa224e850c212b7eR93-R107) [[2]](diffhunk://#diff-0919214587c0ea19d221514a6e92cb7eb455fa0c40502d14aa224e850c212b7eR117-R121) [[3]](diffhunk://#diff-0919214587c0ea19d221514a6e92cb7eb455fa0c40502d14aa224e850c212b7eR130-R131)

These changes make the ViewModel more robust, easier to reason about, and better suited for concurrent or rapidly changing UI scenarios.

- Refactor `ProductDetailViewModel` to use a declarative `uiState` stream using `flatMapLatest` and `stateIn` instead of manual `MutableStateFlow` updates.
- Replace manual `Job` management in `loadProduct()` with a `loadTrigger` flow to handle asynchronous product fetching.
- Centralize loading state emission and error handling within the flow pipeline using `onStart` and `catch`.
- Update `ProductDetailViewModelTest` to handle reactive state transitions, ensuring the product is loaded and verified in `uiState` before testing cart events.