### PR TITLE
IntegrationTests: Implement ProductDao tests and rename product retrieval method

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,6 +109,7 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    androidTestImplementation(libs.turbine)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     testImplementation(libs.turbine)

--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/builder/ProductEntityBuilder.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/builder/ProductEntityBuilder.kt
@@ -1,0 +1,34 @@
+package com.amrubio27.cursotestingandroid.core.builder
+
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.entity.ProductEntity
+
+class ProductEntityBuilder {
+    private var id: String = "product-1"
+    private var name: String = "Producto de pruebas"
+    private var description: String = "Descripción del producto de pruebas"
+    private var price: Double = 10.0
+    private var stock: Int = 10
+    private var imageUrl: String? = null
+    private var category: String = "Categoría de pruebas"
+
+    fun withId(id: String) = apply { this.id = id }
+    fun withName(name: String) = apply { this.name = name }
+    fun withDescription(description: String) = apply { this.description = description }
+    fun withPrice(price: Double) = apply { this.price = price }
+    fun withStock(stock: Int) = apply { this.stock = stock }
+    fun withImageUrl(imageUrl: String?) = apply { this.imageUrl = imageUrl }
+    fun withCategory(category: String) = apply { this.category = category }
+
+    fun build() = ProductEntity(
+        id = id,
+        name = name,
+        description = description,
+        price = price,
+        stock = stock,
+        imageUrl = imageUrl,
+        category = category
+    )
+}
+
+fun productEntity(block: ProductEntityBuilder.() -> Unit = {}) =
+    ProductEntityBuilder().apply(block).build()

--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/dao/ProductDaoTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/dao/ProductDaoTest.kt
@@ -1,0 +1,130 @@
+package com.amrubio27.cursotestingandroid.productlist.data.local.database.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.amrubio27.cursotestingandroid.core.builder.productEntity
+import com.amrubio27.cursotestingandroid.core.data.local.database.MiniMarketDatabase
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ProductDaoTest {
+    private lateinit var database: MiniMarketDatabase
+    private lateinit var dao: ProductDao
+
+    //Se ejecuta antes de los tests y es en el que se instancian las cosas que le demos
+    @Before
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(), //contexto del test
+            MiniMarketDatabase::class.java
+        ).build() //crea una base de datos nueva en memoria para testearla
+        dao = database.productDao()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun givenEmptyDataBase_whenGetAllProducts_thenEmitsEmptyList() = runTest {
+
+        val products = dao.getAllProducts().first()
+        assertTrue(products.isEmpty())
+    }
+
+    @Test
+    fun givenInsertedProduct_whenGetProductById_thenReturnsProduct() = runTest {
+        val id = "id"
+        val p = productEntity { withId(id) }
+        dao.insertAllProducts(listOf(p))
+
+        val product = dao.getProductById(id).first()
+
+        assertNotNull(product)
+        assertEquals(id, product.id)
+    }
+
+    @Test
+    fun givenThreeProducts_whenGetProductsByIds_thenReturnsRequestSubset() = runTest {
+        dao.insertAllProducts(
+            listOf(
+                productEntity { withId("1") },
+                productEntity { withId("2") },
+                productEntity { withId("3") }
+            ))
+
+        val products = dao.getProductsByIds(listOf("1", "3")).first()
+
+        assertTrue(products.any { it.id == "1" })
+        assertTrue(products.any { it.id == "3" })
+        assertTrue(products.none { it.id == "2" })
+    }
+
+    @Test
+    fun givenOldProducts_whenREplaceAll_thenOnlyNewProductsRemain() = runTest {
+        dao.insertAllProducts(
+            listOf(
+                productEntity { withId("old-1") },
+                productEntity { withId("old-2") }
+            ))
+
+        val newProducts = listOf(
+            productEntity { withId("new-1") },
+            productEntity { withId("new-2") },
+            productEntity { withId("new-3") }
+        )
+
+        dao.replaceAll(newProducts)
+
+        val result = dao.getAllProducts().first()
+
+        assertEquals(newProducts.size, result.size)
+        assertTrue(result.none {
+            it.id == "old-1" || it.id == "old-2"
+        })
+        assertTrue(result.any { it.id == "new-1" } && result.any { it.id == "new-2" } && result.any { it.id == "new-3" })
+    }
+
+    @Test
+    fun givenExistingProduct_whenInsertSameIdWithDifferentData_thenReplaceOldData() = runTest {
+        val productId = "id"
+        val p1 = productEntity { withId(productId); withName("pan") }
+        dao.insertAllProducts(listOf(p1))
+
+        val p2 = productEntity { withId(productId); withName("leche") }
+        dao.insertAllProducts(listOf(p2))
+
+        val result = dao.getAllProducts().first()
+        assertTrue(result.size == 1)
+        assertEquals("leche", result.first().name)
+    }
+
+    @Test
+    fun givenFlowSubscribed_whenInsertAfterSubscribe_thenEmitsUpdateList() = runTest {
+        dao.getAllProducts().test {
+            val initial = awaitItem()
+            assertTrue(initial.isEmpty())
+
+            dao.insertAllProducts(listOf(productEntity { withId("2") }))
+
+            val updated = awaitItem()
+
+            assertEquals(1, updated.size)
+            assertEquals("2", updated.first().id)
+
+            cancelAndIgnoreRemainingEvents()
+
+        }
+    }
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/LocalDataSource.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/LocalDataSource.kt
@@ -15,7 +15,7 @@ class LocalDataSource @Inject constructor(
     private val promotionDao: PromotionDao,
     private val cartItemDao: CartItemDao
 ) {
-    fun getAllProducts(): Flow<List<ProductEntity>> = productDao.getProducts()
+    fun getAllProducts(): Flow<List<ProductEntity>> = productDao.getAllProducts()
     fun getAllPromotions(): Flow<List<PromotionEntity>> = promotionDao.getAllPromotions()
 
 

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/dao/ProductDao.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/dao/ProductDao.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface ProductDao {
     @Query("SELECT * FROM products")
-    fun getProducts(): Flow<List<ProductEntity>>
+    fun getAllProducts(): Flow<List<ProductEntity>>
 
     @Query("SELECT * FROM products WHERE id = :id")
     fun getProductById(id: String): Flow<ProductEntity>


### PR DESCRIPTION
This pull request introduces comprehensive instrumentation tests for the `ProductDao` and refactors the product data access interface for clarity and consistency. It also adds a builder utility for test data setup and updates dependencies to support testing with flows.

**Testing improvements:**

* Added a new file, `ProductDaoTest.kt`, with extensive instrumentation tests for the `ProductDao`, covering scenarios like retrieving, inserting, replacing, and updating products in the database.
* Introduced a `ProductEntityBuilder` utility and a `productEntity` function in `ProductEntityBuilder.kt` to simplify and standardize the creation of test product entities.

**API and code consistency:**

* Renamed the `ProductDao` method from `getProducts()` to `getAllProducts()` for clearer intent and updated its usage throughout the codebase, including in `LocalDataSource`. [[1]](diffhunk://#diff-66ae2e8296204c930ef28b298ecec3d09cfff3214a42ab8e914853730492a133L14-R14) [[2]](diffhunk://#diff-01b5d3542320806fba15247b6d5aa0bf9800e672097515d15c51a66ff6a1ed88L18-R18)

**Test dependency updates:**

* Added `turbine` as a test dependency to facilitate testing of Kotlin flows in both unit and instrumentation tests.

- Add `ProductDaoTest` to verify Room DAO operations, including fetching by ID, bulk insertion, and data replacement.
- Integrate Turbine in `androidTest` to validate reactive `Flow` emissions from the database.
- Rename `ProductDao.getProducts()` to `getAllProducts()` for better naming consistency and update `LocalDataSource` accordingly.
- Implement a `ProductEntityBuilder` DSL in the `androidTest` source set to simplify the creation of test data.
- Add the `turbine` dependency to `androidTestImplementation` in `build.gradle.kts`.