### PR TITLE
Implement instrumentation tests for CartItemDao operations

### DIFF
--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/cart/data/local/database/dao/CartItemDaoTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/cart/data/local/database/dao/CartItemDaoTest.kt
@@ -1,0 +1,131 @@
+package com.amrubio27.cursotestingandroid.cart.data.local.database.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amrubio27.cursotestingandroid.core.builder.cartItemEntity
+import com.amrubio27.cursotestingandroid.core.data.local.database.MiniMarketDatabase
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CartItemDaoTest {
+
+    private lateinit var database: MiniMarketDatabase
+
+    private lateinit var dao: CartItemDao
+
+    @Before
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            MiniMarketDatabase::class.java
+        ).build()
+        dao = database.cartItemDao()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun givenEmptyCart_whenGetAllCarItems_thenEmitsEmptyList() = runTest {
+        val item = dao.getAllCartItems().first()
+
+        assertTrue(item.isEmpty())
+    }
+
+    @Test
+    fun givenEmptyCart_whenInsertItem_thenItemIsPersisted() = runTest {
+        val id = "id"
+        val quantity = 3
+        val item = cartItemEntity { withProductId(id); withQuantity(quantity) }
+
+        dao.insertCartItem(item)
+
+        val result = dao.getAllCartItems().first()
+
+        assertEquals(1, result.size)
+        assertEquals(quantity, result.first().quantity)
+        assertEquals(id, result.first().productId)
+    }
+
+    @Test
+    fun givenInsertedItem_whenGetItemById_thenReturnsCorrectItem() = runTest {
+        dao.insertCartItem(cartItemEntity { withProductId("id"); withQuantity(3) })
+
+        val result = dao.getCartItemById("id")
+
+        assertEquals("id", result?.productId)
+        assertEquals(3, result?.quantity)
+    }
+
+    @Test
+    fun givenEmptyCart_whenGetItemById_thenReturnsNull() = runTest {
+        val result = dao.getCartItemById("id")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun givenExistingItem_whenUpdateItemQuantity_thenQuantityIsUpdated() = runTest {
+        val id = "id"
+        dao.insertCartItem(cartItemEntity { withProductId(id); withQuantity(1) })
+        dao.updateCartItem(cartItemEntity { withProductId(id); withQuantity(67) })
+
+        val result = dao.getCartItemById(productId = id)
+
+        assertEquals(67, result?.quantity)
+    }
+
+    @Test
+    fun givenItemCart_whenDeleteItem_thenCartBecomesEmpty() = runTest {
+        val p = cartItemEntity { withProductId("id"); withQuantity(1) }
+        dao.insertCartItem(p)
+
+        dao.deleteCartItem(p)
+
+        val result = dao.getAllCartItems().first()
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun givenMultipleItems_whenClearCart_thenAllItemsAreRemoved() = runTest {
+        val p1 = cartItemEntity { withProductId("id1"); withQuantity(1) }
+        val p2 = cartItemEntity { withProductId("id2"); withQuantity(1) }
+        val p3 = cartItemEntity { withProductId("id3"); withQuantity(1) }
+
+        dao.insertCartItem(p1)
+        dao.insertCartItem(p2)
+        dao.insertCartItem(p3)
+
+        dao.clearCart()
+
+        val result = dao.getAllCartItems().first()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun givenExistingItemId_whenInsertDuplicateId_thenItemIsReplaced() = runTest {
+        val p1 = cartItemEntity { withProductId("id1"); withQuantity(1) }
+        val p2 = cartItemEntity { withProductId("id1"); withQuantity(27) }
+
+        dao.insertCartItem(p1)
+        dao.insertCartItem(p2)
+
+        val result = dao.getAllCartItems().first()
+
+        assertEquals(27, result.first().quantity)
+    }
+
+
+}

--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/builder/CarItemEntityBuilder.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/builder/CarItemEntityBuilder.kt
@@ -1,0 +1,17 @@
+package com.amrubio27.cursotestingandroid.core.builder
+
+import com.amrubio27.cursotestingandroid.cart.data.local.database.entity.CartItemEntity
+
+
+class CartItemEntityBuilder {
+    private var productId: String = "cart-item-1"
+    private var quantity: Int = 1
+
+    fun withProductId(productId: String) = apply { this.productId = productId }
+    fun withQuantity(quantity: Int) = apply { this.quantity = quantity }
+
+    fun build() = CartItemEntity(productId, quantity)
+}
+
+fun cartItemEntity(block: CartItemEntityBuilder.() -> Unit = {}) =
+    CartItemEntityBuilder().apply(block).build()


### PR DESCRIPTION
This pull request adds comprehensive instrumentation tests for the `CartItemDao` and introduces a builder utility to simplify the creation of `CartItemEntity` objects in tests. The main goal is to ensure the correctness of cart item database operations and to improve test readability and maintainability.

**Cart item database testing:**

* Added a new test class `CartItemDaoTest` to verify all CRUD operations and behaviors of the `CartItemDao`, including insertion, retrieval, update, deletion, clearing the cart, and handling of duplicate IDs. (`app/src/androidTest/java/com/amrubio27/cursotestingandroid/cart/data/local/database/dao/CartItemDaoTest.kt`)

**Test utility improvements:**

* Introduced `CartItemEntityBuilder` and a `cartItemEntity` factory function to streamline the creation of `CartItemEntity` instances in tests, improving code clarity and reducing boilerplate. (`app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/builder/CarItemEntityBuilder.kt`)

- Add `CartItemDaoTest` to verify Room DAO operations including insertion, retrieval, updates, and deletion.
- Use an in-memory database configuration to ensure test isolation.
- Implement `CartItemEntityBuilder` with a DSL helper to simplify the creation of test data.
- Test specific DAO behaviors such as item replacement on conflict, clearing the table, and retrieving items by ID.
- Utilize `runTest` and `Flow.first()` for handling asynchronous database streams in tests.