### PR TITLE
TAREA: Implement PromotionDaoTest and refactor PromotionEntityBuilder

### DIFF
--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/builder/PromotionEntityBuilder.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/builder/PromotionEntityBuilder.kt
@@ -5,9 +5,7 @@ import com.amrubio27.cursotestingandroid.productlist.data.local.database.entity.
 class PromotionEntityBuilder {
     private var id: String = "promotion-1"
     private var type: String = "PERCENT"
-    private var productsIds: String = """["productId1"]"""
-    private var value: Double = 10.0
-    private var buyQuantity: Int? = null
+    private var productIds: String = """["productId1"]"""
 
     private var startAtEpoch: Long = 1700000000L
     private var endAtEpoch: Long = 1800000000L
@@ -19,9 +17,7 @@ class PromotionEntityBuilder {
 
     fun withId(id: String) = apply { this.id = id }
     fun withType(type: String) = apply { this.type = type }
-    fun withProductIds(productsIds: String) = apply { this.productsIds = productsIds }
-    fun withValue(value: Double) = apply { this.value = value }
-    fun withBuyQuantity(buyQuantity: Int?) = apply { this.buyQuantity = buyQuantity }
+    fun withProductIds(productIds: String) = apply { this.productIds = productIds }
     fun withStartTime(startTime: Long) = apply { this.startAtEpoch = startTime }
     fun withEndTime(endTime: Long) = apply { this.endAtEpoch = endTime }
     fun withPayY(payY: Int?) = apply { this.payY = payY }
@@ -31,7 +27,7 @@ class PromotionEntityBuilder {
     fun build() = PromotionEntity(
         id = id,
         type = type,
-        productIds = productsIds,
+        productIds = productIds,
         startAtEpoch = startAtEpoch,
         endAtEpoch = endAtEpoch,
         buyX = buyX,

--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/dao/PromotionDaoTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/productlist/data/local/database/dao/PromotionDaoTest.kt
@@ -1,0 +1,87 @@
+package com.amrubio27.cursotestingandroid.productlist.data.local.database.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amrubio27.cursotestingandroid.core.builder.promotionEntity
+import com.amrubio27.cursotestingandroid.core.data.local.database.MiniMarketDatabase
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PromotionDaoTest {
+
+    private lateinit var database: MiniMarketDatabase
+
+    private lateinit var dao: PromotionDao
+
+    @Before
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            MiniMarketDatabase::class.java
+        ).build()
+        dao = database.promotionDao()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun givenEmptyDatabase_whenGetAllPromotions_thenEmitsEmptyList() = runTest {
+        val result = dao.getAllPromotions().first()
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun givenPromotionsList_whenInsertPromotions_thenDataIsPersisted() = runTest {
+        val promotions = listOf(
+            promotionEntity { withId("1") },
+            promotionEntity { withId("2") }
+        )
+        dao.insertPromotions(promotions)
+
+        val result = dao.getAllPromotions().first()
+
+        assertEquals(2, result.size)
+        assertEquals(promotions, result)
+    }
+
+    @Test
+    fun givenExistingPromotion_whenInsertSameId_thenPromotionIsReplaced() = runTest {
+        val id = "1"
+        val initialPromotion = promotionEntity { withId(id); withType("PERCENT") }
+        val updatedPromotion = promotionEntity { withId(id); withType("BUY_X_PAY_Y") }
+
+        dao.insertPromotions(listOf(initialPromotion))
+        dao.insertPromotions(listOf(updatedPromotion))
+
+        val result = dao.getAllPromotions().first()
+
+        assertEquals(1, result.size)
+        assertEquals("BUY_X_PAY_Y", result.first().type)
+    }
+
+    @Test
+    fun givenExistingData_whenReplaceAll_thenOldDataIsClearedAndNewDataInserted() = runTest {
+        val oldPromotions = listOf(promotionEntity { withId("OLD") })
+        val newPromotions = listOf(promotionEntity { withId("NEW") })
+
+        dao.insertPromotions(oldPromotions)
+        dao.replaceAll(newPromotions)
+
+        val result = dao.getAllPromotions().first()
+
+        assertEquals(1, result.size)
+        assertEquals("NEW", result.first().id)
+    }
+
+}


### PR DESCRIPTION
This pull request mainly introduces a new test suite for the `PromotionDao` and applies a minor variable naming fix in the `PromotionEntityBuilder`. The new tests ensure the correct behavior of promotion-related database operations, while the builder changes improve consistency in naming.

**Testing improvements:**

* Added a new test class `PromotionDaoTest` to verify `PromotionDao` functionality, including tests for empty database queries, insertion, replacement on duplicate IDs, and replacing all promotions.

**Code quality and consistency:**

* Renamed the variable and method from `productsIds` to `productIds` in `PromotionEntityBuilder` and its builder methods for consistency. [[1]](diffhunk://#diff-72b2805ec7a01c6c1c09374021c50e1af6f7700cb70d9062d61e8dc488608d58L8-R8) [[2]](diffhunk://#diff-72b2805ec7a01c6c1c09374021c50e1af6f7700cb70d9062d61e8dc488608d58L22-R20) [[3]](diffhunk://#diff-72b2805ec7a01c6c1c09374021c50e1af6f7700cb70d9062d61e8dc488608d58L34-R30)

- Add instrumentation tests for `PromotionDao` covering data insertion, persistence, conflict resolution (replace on conflict), and the `replaceAll` transaction.
- Refactor `PromotionEntityBuilder` to align with entity field naming (`productIds`) and remove unused properties (`value`, `buyQuantity`).
- Use Room's in-memory database and `runTest` for isolated DAO testing.