### PR TITLE
Configure Hilt for instrumented testing with custom test runner

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         versionCode = 1
         versionName = "1.0"
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "package com.amrubio27.cursotestingandroid.HiltTestRunner"
     }
 
     buildTypes {
@@ -114,4 +114,5 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     testImplementation(libs.turbine)
+    androidTestImplementation(libs.hilt.android.testing)
 }

--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/HiltTestRunner.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/HiltTestRunner.kt
@@ -1,0 +1,16 @@
+package com.amrubio27.cursotestingandroid
+
+import android.app.Application
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+import dagger.hilt.android.testing.HiltTestApplication
+
+class HiltTestRunner : AndroidJUnitRunner() {
+    override fun newApplication(
+        cl: ClassLoader?,
+        className: String?,
+        context: Context?
+    ): Application? {
+        return super.newApplication(cl, HiltTestApplication::class.java.name, context)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,7 @@ hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref
 hilt-compiler-ksp = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 hilt-lifecycle-viewmodel-compose = { group = "androidx.hilt", name = "hilt-lifecycle-viewmodel-compose", version.ref = "hiltNavigationCompose" }
+hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
 
 #DataStore
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }


### PR DESCRIPTION
This pull request adds support for Hilt dependency injection in Android instrumented tests by introducing a custom test runner and updating the project's dependencies. The main changes ensure that Hilt's testing features are properly integrated and configured for Android instrumentation tests.

**Hilt Testing Integration:**

* Added a custom `HiltTestRunner` class in `HiltTestRunner.kt` to use `HiltTestApplication` for instrumented tests, enabling Hilt dependency injection in tests.
* Updated the `testInstrumentationRunner` in `app/build.gradle.kts` to use the new `HiltTestRunner` class.

**Dependency Updates:**

* Added the `hilt-android-testing` library to the dependencies in `gradle/libs.versions.toml` and included it as an `androidTestImplementation` dependency in `app/build.gradle.kts` to support Hilt in instrumented tests. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR58) [[2]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R117)