### PR TITLE
Implement MockWebServerRule for instrumented testing infrastructure (debug manifest an server rules)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -115,4 +115,5 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     testImplementation(libs.turbine)
     androidTestImplementation(libs.hilt.android.testing)
+    androidTestImplementation(libs.mockwebserver)
 }

--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/mockwebserver/MockWebServerUrlHolder.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/mockwebserver/MockWebServerUrlHolder.kt
@@ -1,0 +1,5 @@
+package com.amrubio27.cursotestingandroid.core.mockwebserver
+
+object MockWebServerUrlHolder {
+    var baseUrl: String = "http//localhost:8080/"
+}

--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/mockwebserver/rules/MockWebServerRule.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/mockwebserver/rules/MockWebServerRule.kt
@@ -1,0 +1,22 @@
+package com.amrubio27.cursotestingandroid.core.mockwebserver.rules
+
+import com.amrubio27.cursotestingandroid.core.mockwebserver.MockWebServerUrlHolder
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+class MockWebServerRule : TestWatcher() {
+    val server = MockWebServer()
+
+    override fun starting(description: Description?) {
+        super.starting(description)
+        server.start()
+        MockWebServerUrlHolder.baseUrl = server.url("/").toString()
+    }
+
+    override fun finished(description: Description?) {
+        super.finished(description)
+        server.shutdown()
+        super.finished(description)
+    }
+}

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:name=".MarketApp"
+        android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.CursoTestingAndroid"
+        android:usesCleartextTraffic="true"
+        tools:ignore="GoogleAppIndexingWarning">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.CursoTestingAndroid">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>


### PR DESCRIPTION
This pull request introduces infrastructure to support instrumented tests using MockWebServer, making it easier to mock network responses in Android tests. It also adds a debug-specific `AndroidManifest.xml` to configure the application for testing.

**Testing infrastructure improvements:**

* Added `MockWebServerRule` class to manage the lifecycle of a `MockWebServer` during instrumented tests, ensuring the server starts and stops with each test and updates the base URL accordingly (`app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/mockwebserver/rules/MockWebServerRule.kt`).
* Introduced `MockWebServerUrlHolder` singleton to hold and update the base URL used by tests, allowing dynamic assignment of the mock server's URL (`app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/mockwebserver/MockWebServerUrlHolder.kt`).
* Added `mockwebserver` as a test dependency in the Gradle build file to enable the use of MockWebServer in Android instrumented tests (`app/build.gradle.kts`).

**Debug build configuration:**

* Added a debug-specific `AndroidManifest.xml` to configure the application for debug builds, including enabling cleartext traffic for easier testing (`app/src/debug/AndroidManifest.xml`).

- Add `mockwebserver` dependency to `app/build.gradle.kts`.
- Implement `MockWebServerRule` as a JUnit `TestWatcher` to manage the server lifecycle and automatically update the base URL.
- Create `MockWebServerUrlHolder` to store and provide the dynamic server URL during tests.
- Add a debug `AndroidManifest.xml` with `usesCleartextTraffic="true"` to allow HTTP connections to the local mock server.