### PR TITLE
Testing DI: Implement Hilt test modules for instrumented testing

### DIFF
--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/di/TestDataModule.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/di/TestDataModule.kt
@@ -1,0 +1,109 @@
+package com.amrubio27.cursotestingandroid.core.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.core.internal.deps.dagger.Module
+import com.amrubio27.cursotestingandroid.cart.data.local.database.dao.CartItemDao
+import com.amrubio27.cursotestingandroid.cart.data.repository.CartItemRepositoryImpl
+import com.amrubio27.cursotestingandroid.cart.domain.repository.CartItemRepository
+import com.amrubio27.cursotestingandroid.core.data.coroutines.DefaultDispatchersProvider
+import com.amrubio27.cursotestingandroid.core.data.local.database.MiniMarketDatabase
+import com.amrubio27.cursotestingandroid.core.data.util.SystemClock
+import com.amrubio27.cursotestingandroid.core.domain.coroutines.DispatchersProvider
+import com.amrubio27.cursotestingandroid.core.domain.util.Clock
+import com.amrubio27.cursotestingandroid.di.DataModule
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.dao.ProductDao
+import com.amrubio27.cursotestingandroid.productlist.data.local.database.dao.PromotionDao
+import com.amrubio27.cursotestingandroid.productlist.data.repository.ProductRepositoryImpl
+import com.amrubio27.cursotestingandroid.productlist.data.repository.PromotionRepositoryImpl
+import com.amrubio27.cursotestingandroid.productlist.data.repository.SettingsRepositoryImpl
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.PromotionRepository
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.SettingsRepository
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import javax.inject.Singleton
+
+private val Context.testingDataStore: DataStore<Preferences> by preferencesDataStore("testing_settings")
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [DataModule::class]
+)
+object TestDataModule {
+    @Provides
+    @Singleton
+    fun provideDispatchersProvider(): DispatchersProvider {
+        return DefaultDispatchersProvider()
+    }
+
+    @Provides
+    @Singleton
+    fun provideProductRepository(
+        productRepositoryImpl: ProductRepositoryImpl
+    ): ProductRepository {
+        return productRepositoryImpl
+    }
+
+    @Provides
+    @Singleton
+    fun providePromotionRepository(
+        promotionRepositoryImpl: PromotionRepositoryImpl
+    ): PromotionRepository {
+        return promotionRepositoryImpl
+    }
+
+
+    @Provides
+    fun provideProductDao(database: MiniMarketDatabase): ProductDao = database.productDao()
+
+    @Provides
+    fun providePromotionDao(database: MiniMarketDatabase): PromotionDao = database.promotionDao()
+
+    @Provides
+    fun providesCartItemDao(database: MiniMarketDatabase): CartItemDao = database.cartItemDao()
+
+    @Provides
+    @Singleton
+    fun provideDatabase(): MiniMarketDatabase {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        return Room.inMemoryDatabaseBuilder(
+            context,
+            MiniMarketDatabase::class.java
+        ).build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideDataStore(): DataStore<Preferences> {
+        return ApplicationProvider.getApplicationContext<Context>().testingDataStore
+    }
+
+    @Provides
+    @Singleton
+    fun provideSettingsRepository(
+        settingsRepositoryImpl: SettingsRepositoryImpl
+    ): SettingsRepository {
+        return settingsRepositoryImpl
+    }
+
+    @Provides
+    @Singleton
+    fun provideCartRepository(
+        cartItemRepositoryImpl: CartItemRepositoryImpl
+    ): CartItemRepository {
+        return cartItemRepositoryImpl
+    }
+
+    @Provides
+    @Singleton
+    fun provideClock(systemClock: SystemClock): Clock {
+        return systemClock
+    }
+}

--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/di/TestNetworkModule.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/di/TestNetworkModule.kt
@@ -1,0 +1,61 @@
+package com.amrubio27.cursotestingandroid.core.di
+
+import androidx.test.espresso.core.internal.deps.dagger.Module
+import com.amrubio27.cursotestingandroid.core.mockwebserver.MockWebServerUrlHolder
+import com.amrubio27.cursotestingandroid.di.NetworkModule
+import com.amrubio27.cursotestingandroid.productlist.data.remote.MiniMarketApiService
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import javax.inject.Singleton
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [NetworkModule::class]
+)
+object TestNetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(): OkHttpClient {
+
+        return OkHttpClient.Builder().build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideJson(): Json {
+        return Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+            coerceInputValues = true
+        }
+    }
+
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(
+        okHttpClient: OkHttpClient,
+        json: Json
+    ): Retrofit {
+        val contentType = "application/json".toMediaType()
+        return Retrofit.Builder()
+            .baseUrl(MockWebServerUrlHolder.baseUrl)
+            .client(okHttpClient)
+            .addConverterFactory(json.asConverterFactory(contentType))
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideMiniMarketApiService(retrofit: Retrofit): MiniMarketApiService {
+        return retrofit.create(MiniMarketApiService::class.java)
+    }
+}


### PR DESCRIPTION
This pull request introduces two new modules for testing: `TestDataModule` and `TestNetworkModule`. These modules provide test-specific implementations and replace the standard dependency injection modules (`DataModule` and `NetworkModule`) during instrumented tests. The main goal is to ensure that tests use in-memory databases and a mock web server, resulting in isolated and reliable test environments.

**Test Dependency Injection Modules:**

*Test Data Module:*
- Adds `TestDataModule`, which provides an in-memory Room database, test-specific `DataStore`, and repositories for use in tests, replacing the production `DataModule`.

*Test Network Module:*
- Adds `TestNetworkModule`, which configures Retrofit to use a mock web server URL, provides a test-specific `OkHttpClient`, and sets up JSON serialization for tests, replacing the production `NetworkModule`.


- Add `TestNetworkModule` to replace the production `NetworkModule`, configuring `Retrofit` to use a dynamic base URL from `MockWebServerUrlHolder`.
- Add `TestDataModule` to replace the production `DataModule`, providing an in-memory Room database and a dedicated testing `DataStore`.
- Provide test-specific bindings for repositories, DAOs, `DispatchersProvider`, and `Clock` within the test modules.
- Use `@TestInstallIn` to ensure these modules are used exclusively during instrumented tests.