### PR TITLE
Implement `ProductRepositoryImplTest` and fix test configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         versionCode = 1
         versionName = "1.0"
 
-        testInstrumentationRunner = "package com.amrubio27.cursotestingandroid.HiltTestRunner"
+        testInstrumentationRunner = "com.amrubio27.cursotestingandroid.HiltTestRunner"
     }
 
     buildTypes {

--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/di/TestDataModule.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/di/TestDataModule.kt
@@ -6,7 +6,6 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.core.internal.deps.dagger.Module
 import com.amrubio27.cursotestingandroid.cart.data.local.database.dao.CartItemDao
 import com.amrubio27.cursotestingandroid.cart.data.repository.CartItemRepositoryImpl
 import com.amrubio27.cursotestingandroid.cart.domain.repository.CartItemRepository
@@ -24,6 +23,7 @@ import com.amrubio27.cursotestingandroid.productlist.data.repository.SettingsRep
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.PromotionRepository
 import com.amrubio27.cursotestingandroid.productlist.domain.repository.SettingsRepository
+import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn

--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/di/TestNetworkModule.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/di/TestNetworkModule.kt
@@ -1,9 +1,9 @@
 package com.amrubio27.cursotestingandroid.core.di
 
-import androidx.test.espresso.core.internal.deps.dagger.Module
 import com.amrubio27.cursotestingandroid.core.mockwebserver.MockWebServerUrlHolder
 import com.amrubio27.cursotestingandroid.di.NetworkModule
 import com.amrubio27.cursotestingandroid.productlist.data.remote.MiniMarketApiService
+import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn

--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/productlist/data/repository/ProductRepositoryImplTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/productlist/data/repository/ProductRepositoryImplTest.kt
@@ -1,0 +1,155 @@
+package com.amrubio27.cursotestingandroid.productlist.data.repository
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amrubio27.cursotestingandroid.core.mockwebserver.MockWebServerUrlHolder
+import com.amrubio27.cursotestingandroid.core.mockwebserver.rules.MockWebServerRule
+import com.amrubio27.cursotestingandroid.productlist.domain.model.Product
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.inject.Inject
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class ProductRepositoryImplTest {
+
+    @get:Rule(order = 0)
+    val mockWebServer = MockWebServerRule()
+
+    @get:Rule(order = 1)
+    val hilt = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var productRepository: ProductRepository
+
+    @Before
+    fun setUp() {
+        hilt.inject()
+    }
+
+    @After
+    fun tearDown() {
+        MockWebServerUrlHolder.baseUrl = "http://localhost:8080/"
+    }
+
+    private val productJson = """
+    {
+      "products":[
+        {"id":"p1","name":"Pan","description":"Pan fresco","priceCents":150,"category":"Comida","stock":10},
+        {"id":"p2","name":"Leche","description":"Leche entera","priceCents":200,"category":"Lácteos","stock":5}
+      ]
+    }
+    """.trimIndent()
+
+    @Test
+    fun givenValidProductsJson_whenRefreshIsCalled_thenDatabaseEmitProductsFromRoom() = runTest {
+        mockWebServer.server.enqueue(
+            MockResponse()
+                .setBody(productJson)
+                .setResponseCode(200)
+        )
+
+        productRepository.refreshProducts()
+
+        val products: List<Product> = productRepository.getProducts().first()
+
+        assertTrue(products.isNotEmpty())
+        assertTrue(products.size == 2)
+        assertEquals("Pan", products.find { it.id == "p1" }?.name)
+    }
+
+    @Test
+    fun givenEmptyProductsJson_whenRefreshIsCalled_thenGetProductsEmitsEmptyList() = runTest {
+        mockWebServer.server.enqueue(
+            MockResponse()
+                .setBody("""{"products":[]}""")
+                .setResponseCode(200)
+        )
+
+        productRepository.refreshProducts()
+
+        val products: List<Product> = productRepository.getProducts().first()
+
+        assertTrue(products.isEmpty())
+    }
+
+    @Test
+    fun givenProductsJson_whenRefreshAndGetProductById_thenReturnsCorrectProduct() = runTest {
+        mockWebServer.server.enqueue(
+            MockResponse()
+                .setBody(productJson)
+                .setResponseCode(200)
+        )
+
+        productRepository.refreshProducts()
+
+        val product: Product? = productRepository.getProductById("p1").first()
+        assertNotNull(product)
+        assertEquals("Pan", product?.name)
+    }
+
+    @Test(expected = Exception::class)
+    fun givenServerReturns500_whenRefreshIsCalled_thenItThrowsException() = runTest {
+        mockWebServer.server.enqueue(
+            MockResponse()
+                .setResponseCode(500)
+        )
+
+        productRepository.refreshProducts()
+    }
+
+    @Test
+    fun givenCachedProducts_whenRefreshWithNewProducts_thenFlowEmitsUpdatedData() = runTest {
+        mockWebServer.server.enqueue(
+            MockResponse()
+                .setBody(productJson)
+                .setResponseCode(200)
+        )
+        productRepository.refreshProducts()
+
+        val productsJsonUpdated: String = """
+        {"products":[
+            {"id":"p1","name":"Pan integral","description":"Pan fresco","priceCents":450,"category":"Comida","stock":10}
+        ]}
+        """.trimIndent()
+
+        mockWebServer.server.enqueue(
+            MockResponse()
+                .setBody(productsJsonUpdated)
+                .setResponseCode(200)
+        )
+        productRepository.refreshProducts()
+
+        val products: List<Product> = productRepository.getProducts().first()
+
+        assertEquals("Pan integral", products.find { it.id == "p1" }?.name)
+        assertEquals(4.5, products.find { it.id == "p1" }?.price)
+    }
+
+    @Test
+    fun givenProductsEndpoint_whenRefreshIsCalled_thenRequestIsGetToCorrectPath() = runTest {
+        mockWebServer.server.enqueue(
+            MockResponse()
+                .setBody(productJson)
+                .setResponseCode(200)
+        )
+        productRepository.refreshProducts()
+
+        val request = mockWebServer.server.takeRequest()
+        assertEquals("GET", request.method)
+        assertTrue(request.path?.contains("data/products.json") == true)
+    }
+
+
+}


### PR DESCRIPTION
This pull request introduces a new test suite for the `ProductRepositoryImpl` class and makes several improvements to dependency injection setup and configuration for testing. The most significant change is the addition of comprehensive integration tests for product data handling, ensuring the repository correctly interacts with the network and local database layers. Additionally, imports related to Dagger's `Module` annotation are corrected to prevent issues with dependency injection in test modules.

**New Product Repository Integration Tests:**

* Added `ProductRepositoryImplTest` with multiple test cases covering product refresh, retrieval by ID, error handling, and endpoint correctness. These tests use Hilt and MockWebServer to simulate network responses and verify database integration.

**Dependency Injection and Test Module Fixes:**

* Corrected Dagger `Module` imports in `TestDataModule.kt` and `TestNetworkModule.kt` to use the actual `dagger.Module` instead of the internal Espresso dependency, preventing potential DI misconfigurations during testing. [[1]](diffhunk://#diff-2eb6f70f1d16fff50108f29880cb196f9fc0bda8fae3f06873fb4056c2dc2709L9) [[2]](diffhunk://#diff-2eb6f70f1d16fff50108f29880cb196f9fc0bda8fae3f06873fb4056c2dc2709R26) [[3]](diffhunk://#diff-ee0b903d7478e52b8812826a7dca9eff3fe51b6be50a8e32856e5239b356a277L3-R6)

**Build Configuration:**

* Fixed the `testInstrumentationRunner` value in `app/build.gradle.kts` to reference the correct class name, ensuring instrumentation tests run with the intended custom runner.

- Add `ProductRepositoryImplTest` to verify `ProductRepository` logic, including data refreshing, local storage retrieval, and error handling using `MockWebServer`.
- Fix incorrect `@Module` imports in `TestNetworkModule` and `TestDataModule` that were referencing internal Espresso packages instead of standard Dagger.
- Correct the `testInstrumentationRunner` class path in `app/build.gradle.kts` by removing the "package" prefix.