### PR TITLE
Implement PromotionRepositoryImplTest with MockWebServer and Hilt

### DIFF
--- a/app/src/androidTest/assets/promotions_buy_x_pay_y.json
+++ b/app/src/androidTest/assets/promotions_buy_x_pay_y.json
@@ -1,0 +1,13 @@
+{
+  "promotions": [
+    {
+      "id": "bxby",
+      "productId": "p1",
+      "type": "BUY_X_PAY_Y",
+      "buyX": 3,
+      "payY": 2,
+      "startAtEpoch": 1900000000,
+      "endAtEpoch": 2000000000
+    }
+  ]
+}

--- a/app/src/androidTest/assets/promotions_percent.json
+++ b/app/src/androidTest/assets/promotions_percent.json
@@ -1,0 +1,12 @@
+{
+  "promotions": [
+    {
+      "id": "promo1",
+      "productId": "p1",
+      "type": "PERCENT",
+      "percent": 10,
+      "startAtEpoch": 1900000000,
+      "endAtEpoch": 2000000000
+    }
+  ]
+}

--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/productlist/data/repository/PromotionRepositoryImplTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/productlist/data/repository/PromotionRepositoryImplTest.kt
@@ -1,0 +1,129 @@
+package com.amrubio27.cursotestingandroid.productlist.data.repository
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amrubio27.cursotestingandroid.core.mockwebserver.MockWebServerUrlHolder
+import com.amrubio27.cursotestingandroid.core.mockwebserver.rules.MockWebServerRule
+import com.amrubio27.cursotestingandroid.productlist.domain.model.Promotion
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.PromotionRepository
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.inject.Inject
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class PromotionRepositoryImplTest {
+    @get:Rule(order = 0)
+    val mockWebServer = MockWebServerRule()
+
+    @get:Rule(order = 1)
+    val hilt = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var promotionRepository: PromotionRepository
+
+    @Before
+    fun setUp() {
+        hilt.inject()
+    }
+
+    @After
+    fun tearDown() {
+        MockWebServerUrlHolder.baseUrl = "http://localhost:8080/"
+    }
+
+    private fun readJson(fileName: String): String {
+        val context =
+            androidx.test.platform.app.InstrumentationRegistry.getInstrumentation().context
+        return context.assets.open(fileName).bufferedReader().use { it.readText() }
+    }
+
+    @Test
+    fun givenActivePromotionsJson_whenRefreshIsCalled_thenFlowEmitsActivePromotions() = runTest {
+        val json = readJson("promotions_percent.json")
+        mockWebServer.server.enqueue(
+            MockResponse()
+                .setBody(json)
+                .setResponseCode(200)
+        )
+
+        promotionRepository.refreshPromotions()
+
+        val promotions: List<Promotion> = promotionRepository.getActivePromotions().first()
+
+        assertTrue(promotions.isNotEmpty())
+    }
+
+    @Test
+    fun givenEmptyPromotionsJson_whenRefreshIsCalled_thenListIsEmpty() = runTest {
+        mockWebServer.server.enqueue(
+            MockResponse()
+                .setBody("""{"promotions":[]}""")
+                .setResponseCode(200)
+        )
+
+        promotionRepository.refreshPromotions()
+
+        val promotions: List<Promotion> = promotionRepository.getActivePromotions().first()
+
+        assertTrue(promotions.isEmpty())
+    }
+
+    @Test
+    fun givenBuyXPayYJson_whenRefreshIsCalled_thenDomainMapsQuantitiesCorrectly() = runTest {
+        val json: String = readJson(fileName = "promotions_buy_x_pay_y.json")
+        mockWebServer.server.enqueue(
+            MockResponse()
+                .setBody(json)
+                .setResponseCode(200)
+        )
+
+        promotionRepository.refreshPromotions()
+
+        val promotion: Promotion? =
+            promotionRepository.getActivePromotions().first().find { it.id == "bxby" }
+
+        assertNotNull(promotion)
+        assertEquals(2.0, promotion?.value)
+        assertEquals(3, promotion?.buyQuantity)
+    }
+
+    @Test(expected = Exception::class)
+    fun givenServerReturns500_whenRefreshIsCalled_thenItThrowsException() = runTest {
+        mockWebServer.server.enqueue(
+            MockResponse()
+                .setResponseCode(500)
+        )
+
+        promotionRepository.refreshPromotions()
+    }
+
+    @Test
+    fun givenPromotionEndpoint_whenRefreshIsCalled_thenRequestIsGetToCorrectPath() = runTest {
+        val json: String = readJson(fileName = "promotions_buy_x_pay_y.json")
+        mockWebServer.server.enqueue(
+            MockResponse()
+                .setBody(json)
+                .setResponseCode(200)
+        )
+
+        promotionRepository.refreshPromotions()
+
+        val request: RecordedRequest = mockWebServer.server.takeRequest()
+        assertEquals("GET", request.method)
+        assertTrue(request.path?.contains("data/promotions.json") == true)
+    }
+
+
+}


### PR DESCRIPTION
This pull request adds instrumentation tests for the `PromotionRepositoryImpl` to ensure correct handling of promotion data from the backend. It introduces new test assets for different promotion types and verifies the repository's behavior under various scenarios, including successful data parsing, empty responses, error handling, and correct endpoint usage.

**PromotionRepositoryImpl instrumentation tests:**

- Added `PromotionRepositoryImplTest` with tests for:
  - Correct parsing and mapping of percent and "Buy X Pay Y" promotions from backend responses.
  - Handling of empty promotion lists and server errors.
  - Ensuring requests use the correct HTTP method and endpoint path.

**Test assets for promotions:**

- Added `promotions_percent.json` asset for percent-based promotions.
- Added `promotions_buy_x_pay_y.json` asset for "Buy X Pay Y" promotions.

- Add `PromotionRepositoryImplTest` to `androidTest` to verify network synchronization and domain mapping.
- Use `MockWebServerRule` to intercept network calls and `HiltAndroidRule` for dependency injection.
- Add test JSON assets `promotions_percent.json` and `promotions_buy_x_pay_y.json` to simulate different promotion types.
- Implement test cases for successful data ingestion, empty responses, server error handling, and request verification.