### PR TITLE
Add integration tests for SettingsRepositoryImpl functionality

### DIFF
--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/productlist/data/repository/SettingsRepositoryImplTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/productlist/data/repository/SettingsRepositoryImplTest.kt
@@ -1,0 +1,97 @@
+package com.amrubio27.cursotestingandroid.productlist.data.repository
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amrubio27.cursotestingandroid.core.domain.model.ThemeMode
+import com.amrubio27.cursotestingandroid.core.mockwebserver.MockWebServerUrlHolder
+import com.amrubio27.cursotestingandroid.core.mockwebserver.rules.MockWebServerRule
+import com.amrubio27.cursotestingandroid.productlist.domain.model.SortOption
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.SettingsRepository
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.inject.Inject
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class SettingsRepositoryImplTest {
+    @get:Rule(order = 0)
+    val mockWebServer = MockWebServerRule()
+
+    @get:Rule(order = 1)
+    val hilt = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var settingsRepository: SettingsRepository
+
+    @Before
+    fun setUp() = runTest {
+        hilt.inject()
+        (settingsRepository as? SettingsRepositoryImpl)?.clear()
+    }
+
+    @After
+    fun tearDown() {
+        MockWebServerUrlHolder.baseUrl = "http://localhost:8080/"
+    }
+
+    @Test
+    fun givenNoDataSaved_whenInStockOnlyIsRead_thenReturnsDefaultFalse() = runTest {
+        val result: Boolean = settingsRepository.inStockOnly.first()
+        assertTrue(!result)
+    }
+
+    @Test
+    fun givenNoDataSaved_whenFilterVisibleIsRead_thenReturnsDefaultTrue() = runTest {
+        val result: Boolean = settingsRepository.filtersVisible.first()
+        assertTrue(result)
+    }
+
+    @Test
+    fun givenNoDataSaved_whenSelectCategoryIsRead_thenReturnsDefaultNull() = runTest {
+        val result: String? = settingsRepository.selectedCategory.first()
+        assertNull(result)
+    }
+
+    @Test
+    fun givenNoDataSaved_whenThemeModeIsRead_thenReturnsDefaultSystem() = runTest {
+        assertEquals(ThemeMode.SYSTEM, settingsRepository.themeMode.first())
+    }
+
+    @Test
+    fun givenNoDataSaved_whenSortOptionIsRead_thenReturnsDefaultSystem() = runTest {
+        assertEquals(SortOption.NONE, settingsRepository.sortOption.first())
+    }
+
+    @Test
+    fun givenRepository_whenSetFilterVisibleToFalse_thenPersistValue() = runTest {
+        settingsRepository.setFiltersVisible(false)
+        val result: Boolean = settingsRepository.filtersVisible.first()
+        assertTrue(!result)
+    }
+
+    @Test
+    fun givenMultipleSettingsChanges_whenReadAll_thenStateIsConsistent() = runTest {
+        settingsRepository.setFiltersVisible(false)
+        settingsRepository.setInStockOnly(true)
+        settingsRepository.setSortOption(SortOption.DISCOUNT)
+        settingsRepository.setThemeMode(ThemeMode.DARK)
+        settingsRepository.setSelectedCategory("papas")
+
+        assertTrue(!settingsRepository.filtersVisible.first())
+        assertEquals(ThemeMode.DARK, settingsRepository.themeMode.first())
+        assertEquals("papas", settingsRepository.selectedCategory.first())
+        assertEquals(SortOption.DISCOUNT, settingsRepository.sortOption.first())
+        assertEquals(true, settingsRepository.inStockOnly.first())
+    }
+
+
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/data/repository/SettingsRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.amrubio27.cursotestingandroid.productlist.data.repository
 
+import androidx.annotation.VisibleForTesting
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
@@ -99,5 +100,10 @@ class SettingsRepositoryImpl @Inject constructor(
         dataStore.edit { preferences ->
             preferences[SORT_OPTION_KEY] = value.name
         }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    suspend fun clear() {
+        dataStore.edit { it.clear() }
     }
 }


### PR DESCRIPTION
This pull request introduces comprehensive integration tests for the `SettingsRepositoryImpl` class, ensuring that its default values and state persistence work as expected. Additionally, it adds a `clear()` method to facilitate test setup and cleanup.

**Testing improvements:**

* Added a new test class `SettingsRepositoryImplTest` with multiple tests that verify default values, value persistence, and state consistency for settings such as filters visibility, in-stock only, selected category, theme mode, and sort option.

**Codebase changes to support testing:**

* Introduced a `@VisibleForTesting` `clear()` suspend function in `SettingsRepositoryImpl` to allow clearing the DataStore during tests.
* Added the `@VisibleForTesting` import to `SettingsRepositoryImpl.kt` to support the new testing-only method.

- Create `SettingsRepositoryImplTest` to verify default settings values and persistence logic using Hilt and `AndroidJUnit4`.
- Add test cases for checking default states of theme mode, sorting options, and filter visibility.
- Verify consistency of the repository state after multiple settings updates.
- Add a `@VisibleForTesting` `clear()` method to `SettingsRepositoryImpl` to allow resetting the underlying `DataStore` state between test runs.