### PR TITLE
Implement integration tests for `CartItemRepositoryImpl`

### DIFF
--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/cart/data/repository/CartItemRepositoryImplTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/cart/data/repository/CartItemRepositoryImplTest.kt
@@ -1,0 +1,118 @@
+package com.amrubio27.cursotestingandroid.cart.data.repository
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amrubio27.cursotestingandroid.cart.domain.repository.CartItemRepository
+import com.amrubio27.cursotestingandroid.core.domain.model.AppError
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.inject.Inject
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class CartItemRepositoryImplTest {
+
+    @get:Rule
+    val hilt = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var cartItemRepository: CartItemRepository
+
+    @Before
+    fun setUp() = runTest {
+        hilt.inject()
+        cartItemRepository.clearCart()
+    }
+
+    @Test
+    fun givenNoData_whenGetCartItems_thenReturnsEmptyList() = runTest {
+        val items = cartItemRepository.getCartItems().first()
+        assertTrue(items.isEmpty())
+    }
+
+    //esencial
+    @Test
+    fun givenItem_whenAddToCart_thenPersistItem() = runTest {
+        cartItemRepository.addToCart("p1", 2)
+
+        val items = cartItemRepository.getCartItems().first()
+        assertEquals(1, items.size)
+        assertEquals("p1", items[0].productId)
+        assertEquals(2, items[0].quantity)
+    }
+
+    //esencial
+    @Test
+    fun givenExistingItem_whenAddToCart_thenIncrementQuantity() = runTest {
+        cartItemRepository.addToCart("p1", 2)
+        cartItemRepository.addToCart("p1", 3)
+
+        val item = cartItemRepository.getCartItemById("p1")
+        assertEquals(5, item?.quantity)
+    }
+
+    @Test
+    fun givenItemInCart_whenRemoveFromCart_thenItemIsDeleted() = runTest {
+        cartItemRepository.addToCart("p1", 2)
+        cartItemRepository.removeFromCart("p1")
+
+        val items = cartItemRepository.getCartItems().first()
+        assertTrue(items.isEmpty())
+    }
+
+    //esencial
+    @Test(expected = AppError.NotFoundError::class)
+    fun givenNoItem_whenRemoveFromCart_thenThrowsNotFoundError() = runTest {
+        cartItemRepository.removeFromCart("non_existent")
+    }
+
+    //esencial
+    @Test
+    fun givenItemInCart_whenUpdateQuantity_thenQuantityIsUpdated() = runTest {
+        cartItemRepository.addToCart("p1", 2)
+        cartItemRepository.updateQuantity("p1", 10)
+
+        val item = cartItemRepository.getCartItemById("p1")
+        assertEquals(10, item?.quantity)
+    }
+
+    @Test(expected = AppError.NotFoundError::class)
+    fun givenNoItem_whenUpdateQuantity_thenThrowsNotFoundError() = runTest {
+        cartItemRepository.updateQuantity("non_existent", 5)
+    }
+
+    //esencial
+    @Test
+    fun givenItemsInCart_whenClearCart_thenCartIsEmpty() = runTest {
+        cartItemRepository.addToCart("p1", 2)
+        cartItemRepository.addToCart("p2", 1)
+
+        cartItemRepository.clearCart()
+
+        val items = cartItemRepository.getCartItems().first()
+        assertTrue(items.isEmpty())
+    }
+
+    @Test
+    fun givenItem_whenGetCartItemById_thenReturnsItem() = runTest {
+        cartItemRepository.addToCart("p1", 5)
+
+        val item = cartItemRepository.getCartItemById("p1")
+        assertEquals("p1", item?.productId)
+        assertEquals(5, item?.quantity)
+    }
+
+    @Test
+    fun givenNoItem_whenGetCartItemById_thenReturnsNull() = runTest {
+        val item = cartItemRepository.getCartItemById("non_existent")
+        assertNull(item)
+    }
+}


### PR DESCRIPTION
This pull request adds a comprehensive test class for the `CartItemRepositoryImpl` implementation. The new tests cover all major behaviors of the cart item repository, ensuring correct handling of adding, updating, removing, and retrieving cart items, as well as error cases.

**Repository test coverage improvements:**

* Added `CartItemRepositoryImplTest` with tests for adding items, incrementing quantities, removing items, updating quantities, clearing the cart, and retrieving items by ID.
* Included tests for error handling, such as attempting to remove or update non-existent cart items, which are expected to throw `AppError.NotFoundError`.
* Utilized Hilt for dependency injection in the test setup to ensure proper initialization of repository dependencies.
* Ensured that the repository is cleared before each test to maintain test isolation and reliability.

- Add `CartItemRepositoryImplTest` to verify the repository's behavior within the Android instrumentation environment.
- Use `HiltAndroidRule` to inject the repository and manage its dependencies.
- Implement test cases for core cart operations:
    - Adding new items and incrementing quantities for existing items.
    - Retrieving the full list of items or specific items by ID.
    - Updating item quantities and removing items from the cart.
    - Clearing the entire cart state.
- Verify error handling by asserting that `AppError.NotFoundError` is thrown for operations on non-existent items.