### PR TITLE
Implement integration tests for `CartViewModel` and add Turbine testi…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,4 +116,5 @@ dependencies {
     testImplementation(libs.turbine)
     androidTestImplementation(libs.hilt.android.testing)
     androidTestImplementation(libs.mockwebserver)
+    androidTestImplementation(libs.kotlin.test)
 }

--- a/app/src/androidTest/assets/products_list_updated.json
+++ b/app/src/androidTest/assets/products_list_updated.json
@@ -1,0 +1,11 @@
+{
+  "products": [
+    {
+      "id": "updated-p1",
+      "name": "Pan integral",
+      "priceCents": 450,
+      "category": "Comida",
+      "stock": 10
+    }
+  ]
+}

--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/OfflineFirstIntegrationTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/OfflineFirstIntegrationTest.kt
@@ -1,0 +1,136 @@
+package com.amrubio27.cursotestingandroid.core
+
+import com.amrubio27.cursotestingandroid.core.data.local.database.MiniMarketDatabase
+import com.amrubio27.cursotestingandroid.core.domain.model.AppError
+import com.amrubio27.cursotestingandroid.core.mockwebserver.MiniMarketApiDispatcher
+import com.amrubio27.cursotestingandroid.core.mockwebserver.MockWebServerUrlHolder
+import com.amrubio27.cursotestingandroid.core.mockwebserver.ProductErrorDispatcher
+import com.amrubio27.cursotestingandroid.core.mockwebserver.rules.MockWebServerRule
+import com.amrubio27.cursotestingandroid.core.utils.asAsset
+import com.amrubio27.cursotestingandroid.productlist.domain.repository.ProductRepository
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import jakarta.inject.Inject
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+@HiltAndroidTest
+class OfflineFirstIntegrationTest {
+
+    companion object {
+        const val DEFAULT_PRODUCT_ASSET = "products_list_default.json"
+        const val UPDATE_PRODUCT_ASSET = "products_list_updated.json"
+        const val DEFAULT_PRODUCT_SIZE = 3
+        const val UPDATE_PRODUCT_SIZE = 1
+    }
+
+    @get:Rule(order = 0)
+    val mockWebServer = MockWebServerRule()
+
+    @get:Rule(order = 1)
+    val hilt = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var db: MiniMarketDatabase
+
+    @Inject
+    lateinit var productRepository: ProductRepository
+
+    @Before
+    fun setUp() {
+        hilt.inject()
+        db.clearAllTables()
+    }
+
+    @After
+    fun tearDown() {
+        MockWebServerUrlHolder.baseUrl = "http://localhost:8080/"
+    }
+
+    @Test
+    fun givenSuccessfulRefresh_whenGetProducts_thenRoomContainsRemoteProducts() = runTest {
+        serveProductsFromAsset(DEFAULT_PRODUCT_ASSET)
+
+        productRepository.refreshProducts()
+
+        val cachedProducts = productRepository.getProducts().first { products ->
+            products.size == DEFAULT_PRODUCT_SIZE
+        }
+
+        assertEquals(DEFAULT_PRODUCT_SIZE, cachedProducts.size)
+    }
+
+    @Test
+    fun givenEmptyCacheAndFailedRefresh_whenGetProducts_thenEmitsEmptyList() = runTest {
+        serveProductsError()
+
+        /*val result: Result<Unit> = runCatching { productRepository.refreshProducts() }
+        assertTrue(result.isFailure)*/
+
+        assertFailsWith<AppError.NetworkError> {
+            productRepository.refreshProducts()
+        }
+
+        val products = productRepository.getProducts().first { it.isEmpty() }
+
+        assertTrue(products.isEmpty())
+    }
+
+    @Test
+    fun givenCachedProductsAndFailedRefresh_whenGetProducts_thenReturnsPreviousCache() = runTest {
+        serveProductsFromAsset(DEFAULT_PRODUCT_ASSET)
+        productRepository.refreshProducts()
+        productRepository.getProducts().first { products ->
+            products.size == DEFAULT_PRODUCT_SIZE
+        }
+
+        serveProductsError()
+        assertFailsWith<AppError.NetworkError> {
+            productRepository.refreshProducts()
+        }
+
+        val cachedProducts = productRepository.getProducts().first { products ->
+            products.size == DEFAULT_PRODUCT_SIZE
+        }
+
+        assertEquals(DEFAULT_PRODUCT_SIZE, cachedProducts.size)
+    }
+
+    @Test
+    fun givenCachedProducts_whenRefreshWithNewPayload_thenContainsOnlyLatestProducts() = runTest {
+        serveProductsFromAsset(DEFAULT_PRODUCT_ASSET)
+        productRepository.refreshProducts()
+        productRepository.getProducts().first { products ->
+            products.size == DEFAULT_PRODUCT_SIZE
+        }
+
+        serveProductsFromAsset(UPDATE_PRODUCT_ASSET)
+        productRepository.refreshProducts()
+
+        val updatedProducts = productRepository.getProducts().first {
+            it.size == UPDATE_PRODUCT_SIZE
+        }
+
+        assertEquals(UPDATE_PRODUCT_SIZE, updatedProducts.size)
+        assertEquals("updated-p1", updatedProducts.first().id)
+        assertEquals("Pan integral", updatedProducts.first().name)
+    }
+
+    private fun serveProductsFromAsset(assetName: String) {
+        mockWebServer.server.dispatcher = MiniMarketApiDispatcher(
+            productJson = assetName.asAsset()
+        )
+    }
+
+    private fun serveProductsError() {
+        mockWebServer.server.dispatcher = ProductErrorDispatcher()
+    }
+
+}

--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/mockwebserver/ProductErrorDispatcher.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/mockwebserver/ProductErrorDispatcher.kt
@@ -1,0 +1,16 @@
+package com.amrubio27.cursotestingandroid.core.mockwebserver
+
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
+
+class ProductErrorDispatcher : Dispatcher() {
+    override fun dispatch(request: RecordedRequest): MockResponse {
+        return when {
+            request.path?.contains("products.json") == true -> MockResponse()
+                .setResponseCode(500)
+
+            else -> MockResponse().setResponseCode(404)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -87,6 +87,8 @@ androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lif
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockwebserver" }
+kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
+
 
 
 [plugins]


### PR DESCRIPTION
# 🧪 feat(testing): tests offline-first de integración para `ProductRepository` + dispatcher de error y asset actualizado

## 📌 Resumen

Esta PR introduce una suite de tests de integración orientados al comportamiento *offline-first* del `ProductRepository`. Se añaden pruebas que validan: persistencia de datos remotos en Room, política de fallback a caché cuando falla la red, y reemplazo completo de la caché cuando el servidor devuelve un payload nuevo. Además se incluye un `Dispatcher` para simular errores de servidor (`500`) y un asset con un payload actualizado para comprobar la sustitución de la caché.

Los cambios buscan garantizar que las transiciones remotas↔locales se comporten como contrato (persistir, servir caché si falla, y reemplazar con payloads nuevos), y que los tests actúen como documentación y seguridad contra regresiones.

---

## 🎯 Objetivo de los cambios

Comprobar de forma reproducible y determinista que:

- Un refresh exitoso descarga y persiste productos en Room.
- Si no existe caché y el refresh falla, se propaga el error y `getProducts()` emite lista vacía.
- Si existe caché y el refresh remoto falla, el repositorio sigue exponiendo la caché anterior (fallback).
- Si existe caché y el servidor devuelve un payload distinto, la caché se reemplaza por completo con el nuevo payload.

Además, facilitar la creación de escenarios de fallo mediante un `Dispatcher` reutilizable y centralizar assets de prueba.

---

## ✨ Archivos añadidos / modificados

- `app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/OfflineFirstIntegrationTest.kt` — Tests de integración offline-first (nueva clase).
- `app/src/androidTest/java/com/amrubio27/cursotestingandroid/core/mockwebserver/ProductErrorDispatcher.kt` — `Dispatcher` que devuelve 500 para `products.json` (nuevo).
- `app/src/androidTest/assets/products_list_updated.json` — Asset con payload actualizado (nuevo).
- Dependencias relevantes (ya presentes o referenciadas): `MockWebServer`, `Turbine`, `Hilt`, `Room`, `kotlinx-coroutines-test` (ver `app/build.gradle.kts` y `gradle/libs.versions.toml`).

---

## 🧩 Problema que se resuelve

En diseños offline-first la lógica requiere pruebas integradas que validen la cadena completa de responsabilidades: petición HTTP, deserialización, persistencia en Room y emisión a través de Flow. Los tests unitarios no garantizan que todas estas piezas encajen en conjunto. Con estos tests:

- Documentamos el comportamiento esperado del `ProductRepository`.
- Detectamos problemas de integración (p. ej. deserialización, DAO, transacciones).
- Protegemos contra regresiones en la política de sincronización (replace vs merge, fallback).

---

## ✍️ Explicación detallada de los cambios (por archivo)

### `OfflineFirstIntegrationTest.kt`
Contiene 4 tests principales que cubren la política offline-first:

1. `givenSuccessfulRefresh_whenGetProducts_thenRoomContainsRemoteProducts`
   - Qué hace: sirve el asset `products_list_default.json` por `MockWebServer`, llama a `productRepository.refreshProducts()`, y espera que `productRepository.getProducts()` emita una lista con el tamaño esperado.
   - Por qué: valida la ruta completa Retrofit → parseo → insert en Room → emisión del Flow. Verifica que los datos remotos se persisten correctamente.

2. `givenEmptyCacheAndFailedRefresh_whenGetProducts_thenEmitsEmptyList`
   - Qué hace: configura `ProductErrorDispatcher` (500), llama a `refreshProducts()` y espera que la llamada lance `AppError.NetworkError`; verifica además que `getProducts()` emite una lista vacía.
   - Por qué: asegura comportamiento correcto cuando no hay caché y el refresh falla: no inventamos datos y propagamos el error.

3. `givenCachedProductsAndFailedRefresh_whenGetProducts_thenReturnsPreviousCache`
   - Qué hace: primero carga caché con un refresh exitoso; luego hace que el servidor devuelva error y vuelve a refrescar; espera que la caché previa siga accesible desde `getProducts()`.
   - Por qué: en offline-first, si existe caché y el remoto falla, la aplicación debe seguir sirviendo la caché para mantener UX y disponibilidad.

4. `givenCachedProducts_whenRefreshWithNewPayload_thenContainsOnlyLatestProducts`
   - Qué hace: carga caché con `products_list_default.json`, después cambia el servidor a `products_list_updated.json` y llama a `refreshProducts()`; espera que Room contenga exclusivamente el nuevo payload.
   - Por qué: valida que el refresh **reemplaza** la caché (comportamiento replace), manteniendo coherencia con el servidor.

Detalles de implementación:
- `setUp()` hace `hilt.inject()` y `db.clearAllTables()` para un estado limpio.
- `MockWebServer` se configura usando `MiniMarketApiDispatcher` (para payloads) o `ProductErrorDispatcher`.
- En los tests se consume el Flow con `.first { condition }` para esperar la condición deseada sin sleeps.

---

### `ProductErrorDispatcher.kt`
- Implementa un `Dispatcher` de `MockWebServer` que responde con `500` a peticiones que contengan `products.json`.
- Ventaja: permite simular fallos de servidor repetibles en múltiples tests sin necesidad de encolar manualmente `MockResponse` en cada caso.

Resumen del código:
```kotlin
class ProductErrorDispatcher : Dispatcher() {
    override fun dispatch(request: RecordedRequest): MockResponse {
        return when {
            request.path?.contains("products.json") == true ->
                MockResponse().setResponseCode(500)
            else -> MockResponse().setResponseCode(404)
        }
    }
}
```

---

###  `products_list_updated.json`
- Un asset con payload distinto (un solo producto `updated-p1`) para validar la sustitución total de la caché en el test `givenCachedProducts_whenRefreshWithNewPayload_thenContainsOnlyLatestProducts`.
- Es esencial para simular una actualización remota que cambia el conjunto de recursos (no sólo campos de un producto).

Contenido clave:
```json
{
  "products": [
    {
      "id": "updated-p1",
      "name": "Pan integral",
      "priceCents": 450,
      "category": "Comida",
      "stock": 10
    }
  ]
}
```

## 🧪 Por qué cada test tiene sentido (explicación didáctica con Given/When/Then)

Hacer explícito el propósito de cada test ayuda a que la PR sirva como apuntes y documentación.

- `givenSuccessfulRefresh_whenGetProducts_thenRoomContainsRemoteProducts`  
  - Given: servidor devuelve payload válido.  
  - When: llamamos a `refreshProducts()`.  
  - Then: el repositorio persiste y emite los productos desde Room.  
  - Lógica validada: persistencia y emisión post-refresh.

- `givenEmptyCacheAndFailedRefresh_whenGetProducts_thenEmitsEmptyList`  
  - Given: caché vacía.  
  - When: el refresh remoto falla (500).  
  - Then: la operación lanza `AppError.NetworkError` y `getProducts()` emite lista vacía.  
  - Lógica validada: propagación correcta del error y estado sin datos cuando no hay caché.

- `givenCachedProductsAndFailedRefresh_whenGetProducts_thenReturnsPreviousCache`  
  - Given: caché con datos previos.  
  - When: el refresh remoto falla.  
  - Then: el repositorio continúa sirviendo la caché previa.  
  - Lógica validada: fallback a caché (offline-first).

- `givenCachedProducts_whenRefreshWithNewPayload_thenContainsOnlyLatestProducts`  
  - Given: caché inicial con varios productos.  
  - When: el servidor devuelve un payload actualizado y ejecutamos refresh.  
  - Then: la caché contiene únicamente los productos del nuevo payload.  
  - Lógica validada: el refresh reemplaza la cache (no combina indebidamente).

Explicar esto en la PR ayuda a futuros lectores a entender no solo qué se prueba, sino por qué es crítico desde el punto de vista del diseño del repositorio.

---

## ✅ Buenas prácticas seguidas

- Tests con nombres claros y descriptivos (Given/When/Then).
- Entorno aislado en `setUp()` (`db.clearAllTables()`).
- Uso de `Dispatcher` para centralizar simulación de respuestas (DRY).
- Assets en `androidTest/assets` para datos de prueba reutilizables.
- Uso de Flow + `.first { condition }` para esperar condiciones sin sleeps.

---

## Conclusión
Con esta PR se refuerza la confiabilidad del comportamiento offline-first del `ProductRepository` y se ofrecen herramientas reproducibles para simular tanto respuestas exitosas como fallos de servidor. Los tests actúan como contrato y documentación de la política de sincronización: persistir, servir caché en fallo y reemplazar en refresh exitoso.