### PR TITLE
Implement `SettingsContent` refactor and initial ui testing

### DIFF
--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreenTest.kt
@@ -1,0 +1,29 @@
+package com.amrubio27.cursotestingandroid.settings.presentation
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import kotlin.test.Test
+
+
+class SettingsScreenTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun firstUITest() {
+        composeRule.setContent {
+            SettingsContent(
+                uiState = SettingsUiState(),
+                onBack = {},
+                onInStockOnlyChange = {},
+                onThemeModeSelected = {}
+            )
+        }
+        composeRule.onNodeWithText("Ajustes").assertIsDisplayed()
+    }
+
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreen.kt
@@ -36,7 +36,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.amrubio27.cursotestingandroid.core.domain.model.ThemeMode
 import com.amrubio27.cursotestingandroid.core.presentation.components.MarketTopAppBar
 
-@Preview
 @Composable
 fun SettingsScreen(
     onBack: () -> Unit = {},
@@ -44,7 +43,23 @@ fun SettingsScreen(
 ) {
 
     val uiState by settingsViewModel.uiState.collectAsStateWithLifecycle()
+    SettingsContent(
+        uiState = uiState,
+        onBack = onBack,
+        onInStockOnlyChange = { newState -> settingsViewModel.setInStockOnly(newState) },
+        onThemeModeSelected = { themeMode -> settingsViewModel.setThemeMode(themeMode) }
+    )
 
+}
+
+@Preview
+@Composable
+fun SettingsContent(
+    uiState: SettingsUiState = SettingsUiState(),
+    onBack: () -> Unit = {},
+    onInStockOnlyChange: (Boolean) -> Unit = {},
+    onThemeModeSelected: (ThemeMode) -> Unit = {}
+) {
     Scaffold(
         topBar = {
             MarketTopAppBar(
@@ -109,9 +124,7 @@ fun SettingsScreen(
 
                         Switch(
                             checked = uiState.inStockOnly,
-                            onCheckedChange = { newState ->
-                                settingsViewModel.setInStockOnly(newState)
-                            }
+                            onCheckedChange = onInStockOnlyChange
                         )
                     }
 
@@ -195,19 +208,19 @@ fun SettingsScreen(
                         ) {
                             SegmentedButton(
                                 shape = SegmentedButtonDefaults.itemShape(0, 3),
-                                onClick = { settingsViewModel.setThemeMode(ThemeMode.SYSTEM) },
+                                onClick = { onThemeModeSelected(ThemeMode.SYSTEM) },
                                 selected = uiState.themeMode == ThemeMode.SYSTEM,
                                 label = { Text("Sistema") }
                             )
                             SegmentedButton(
                                 shape = SegmentedButtonDefaults.itemShape(1, 3),
-                                onClick = { settingsViewModel.setThemeMode(ThemeMode.LIGHT) },
+                                onClick = { onThemeModeSelected(ThemeMode.LIGHT) },
                                 selected = uiState.themeMode == ThemeMode.LIGHT,
                                 label = { Text("Claro") }
                             )
                             SegmentedButton(
                                 shape = SegmentedButtonDefaults.itemShape(2, 3),
-                                onClick = { settingsViewModel.setThemeMode(ThemeMode.DARK) },
+                                onClick = { onThemeModeSelected(ThemeMode.DARK) },
                                 selected = uiState.themeMode == ThemeMode.DARK,
                                 label = { Text("Oscuro") }
                             )


### PR DESCRIPTION
📌 Resumen
Se añade una pantalla de Ajustes implementada en Jetpack Compose (`SettingsScreen` / `SettingsContent`) y una prueba instrumentada básica que valida el renderizado inicial. Además se incluye una entrada en el catálogo de versiones (`libs.versions.toml`) para `kotlin-test` usada en los tests. Estos cambios establecen la base para gestionar preferencias del usuario (filtro de stock, tema de la app) de forma reactiva y testeable.

🎯 Objetivo de los cambios
- Proveer una implementación inicial de la pantalla de Ajustes siguiendo buenas prácticas Compose (separación de capa de estado y UI).
- Habilitar una prueba UI básica para validar que la composición se renderiza correctamente.
- Centralizar dependencias de testing en `libs.versions.toml`.

✨ Cambios principales realizados

1) Nueva UI de Ajustes (separación ViewModel ⇢ UI)
- Archivo: `app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreen.kt`
- Qué contiene:
  - `SettingsScreen(...)`: obtiene estado desde `SettingsViewModel` con `hiltViewModel()` y `collectAsStateWithLifecycle()` (capa contenedora).
  - `SettingsContent(...)`: composable pure de presentación (con `@Preview`) que recibe `uiState` y callbacks para acciones del usuario.
- Por qué:
  - Facilita testeo de la UI en aislamiento y permite que la lógica de estado quede en el ViewModel siguiendo un flujo unidireccional (UI -> ViewModel -> UI).

2) Secciones y controles visuales
- Dentro de `SettingsContent`:
  - Card “Filtros y visualización”:
    - Switch “Solo productos en Stock” enlazado a `uiState.inStockOnly` (callback `onInStockOnlyChange`).
    - Switch “Mostrar impuestos incluídos” aún hardcoded (`checked = true`) — actualmente sin conexión al estado.
  - Card “Apariencia”:
    - Selector de tema usando `SingleChoiceSegmentedButtonRow` con opciones `SYSTEM`, `LIGHT` y `DARK`.
- Por qué:
  - Organización por tarjetas mejora legibilidad y permite añadir secciones futuras de forma ordenada.
  - `SegmentedButton` es apropiado para opciones mutuamente excluyentes (tema).

3) Primer test UI instrumentado
- Archivo: `app/src/androidTest/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreenTest.kt`
- Qué hace:
  - Monta `SettingsContent` con valores por defecto y comprueba que el texto "Ajustes" está visible (`assertIsDisplayed()`).
- Por qué:
  - Provee una comprobación básica que la pantalla se compone correctamente; sirve como punto de partida para tests más completos.

4) Registro de dependencia de testing
- Archivo: `gradle/libs.versions.toml`
- Cambio: se añade la línea
  - `kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }`
- Por qué:
  - Centraliza la dependencia para anotaciones y utilidades de test en Kotlin, coherente con el catálogo de dependencias del proyecto.

🧩 Beneficios de los cambios
- Base clara y mantenible para la gestión de preferencias.
- Arquitectura limpia: separación de responsabilidades entre el ViewModel y la UI.
- Primer test instrumentado que asegura que la pantalla no falla al renderizar.
- Catálogo de dependencias actualizado para tests.

🔧 Archivos modificados / añadidos
- `app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreen.kt` (añadido / modificado)
- `app/src/androidTest/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreenTest.kt` (añadido)
- `gradle/libs.versions.toml` (modificado)

🛠️ Observaciones y recomendaciones (siguientes pasos)
Estas son mejoras prácticas sugeridas para siguientes PRs — no se aplican en este commit:

1. Conectar el switch de “Mostrar impuestos incluídos”
- Actualmente está hardcoded en `checked = true`. Recomiendo:
  - Añadir `inTaxesIncluded: Boolean` a `SettingsUiState`.
  - Implementar `settingsViewModel.setTaxesIncluded(...)` y pasar `uiState.inTaxesIncluded` al switch.
  - Así la UI será completamente controlada por el estado y testeable.

2. Hacer tests de interacción y usar test tags
- El test actual solo verifica renderizado estático. Para robustecer la suite:
  - Añadir `Modifier.testTag("settings_inStock_switch")` y similares en los elementos interactivos.
  - Escribir tests que:
    - Hagan click/toggle sobre el switch `inStock` y verifiquen que se llama el callback o se actualiza el estado (con un fake ViewModel en tests unitarios).
    - Seleccionen las opciones de tema y verifiquen la selección.
- Ejemplo sugerido (no aplicado, solo referencia):
  - En el UI:
    - Switch(..., modifier = Modifier.testTag("settings_inStock_switch"), checked = uiState.inStockOnly, onCheckedChange = onInStockOnlyChange)
  - En test:
    - composeRule.onNodeWithTag("settings_inStock_switch").performClick(); // then assert state change

3. Localización y strings
- Extraer cadenas literales (por ejemplo "Ajustes", "Solo productos en Stock") a recursos string para facilitar internacionalización.

4. Accesibilidad
- Añadir `contentDescription` significativos a los `Icon` y revisar roles y semantics para que la pantalla sea accesible.

5. Reutilización y modularización
- Si se prevé más pantallas con opciones, considerar componentes reutilizables (`SettingRow`, `SettingsCard`) para reducir duplicación.

✅ Conclusión
La PR agrega la pantalla de Ajustes con una implementación inicial bien estructurada y un test UI de humo que garantiza el renderizado. También actualiza el catálogo de dependencias para tests. Es una base sólida para expandir la funcionalidad (conexión de más preferencias, tests de interacción, accesibilidad e internacionalización).