### PR TITLE
Add test tags and localized strings for Settings screen components

### DIFF
--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreenTest.kt
@@ -2,10 +2,25 @@ package com.amrubio27.cursotestingandroid.settings.presentation
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.amrubio27.cursotestingandroid.R
+import com.amrubio27.cursotestingandroid.core.domain.model.ThemeMode
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.SETTINGS_CONTENT
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.SETTINGS_IN_STOCK_SWITCH
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.SETTINGS_TAX_SWITCH
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.TOP_APP_BAR
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.settingsThemeOption
+import junit.framework.TestCase.assertTrue
 import org.junit.Rule
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 
 class SettingsScreenTest {
@@ -13,17 +28,119 @@ class SettingsScreenTest {
     @get:Rule
     val composeRule = createAndroidComposeRule<ComponentActivity>()
 
-    @Test
-    fun firstUITest() {
+    private fun createSettingsScreen(
+        uiState: SettingsUiState = SettingsUiState(),
+        onBack: () -> Unit = {},
+        onInStockOnlyChange: (Boolean) -> Unit = {},
+        onThemeModeSelected: (ThemeMode) -> Unit = {}
+    ) {
         composeRule.setContent {
             SettingsContent(
-                uiState = SettingsUiState(),
-                onBack = {},
-                onInStockOnlyChange = {},
-                onThemeModeSelected = {}
+                uiState = uiState,
+                onBack = onBack,
+                onInStockOnlyChange = onInStockOnlyChange,
+                onThemeModeSelected = onThemeModeSelected
             )
         }
+    }
+
+    @Test
+    fun firstUITest() {
+        createSettingsScreen()
         composeRule.onNodeWithText("Ajustes").assertIsDisplayed()
+    }
+
+    private fun getString(resId: Int): String = composeRule.activity.getString(resId)
+
+    @Test
+    fun givenDefaultSettingsState_whenRendered_thenShowsFilterAndAppearanceSections() {
+        createSettingsScreen(uiState = SettingsUiState())
+
+        composeRule.onNodeWithText(getString(R.string.settings_title)).assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.settings_in_stock_only)).assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.settings_filters_section)).assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.settings_appearance_section))
+            .assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.settings_theme_label)).assertIsDisplayed()
+
+        composeRule.onNodeWithTag(SETTINGS_CONTENT).assertIsDisplayed()
+        composeRule.onNodeWithTag(SETTINGS_IN_STOCK_SWITCH).assertIsOff()
+        composeRule.onNodeWithTag(SETTINGS_TAX_SWITCH).assertIsOn()
+    }
+
+    @Test
+    fun givenInStockOnlyFalse_whenRendered_thenSwitchIsOff() {
+        createSettingsScreen(uiState = SettingsUiState(inStockOnly = false))
+
+        composeRule.onNodeWithTag(testTag = SETTINGS_IN_STOCK_SWITCH).assertIsOff()
+    }
+
+    @Test
+    fun givenInStockOnlyTrue_whenRendered_thenSwitchIsOn() {
+        createSettingsScreen(uiState = SettingsUiState(inStockOnly = true))
+
+        composeRule.onNodeWithTag(testTag = SETTINGS_IN_STOCK_SWITCH).assertIsOn()
+    }
+
+    @Test
+    fun givenLightTheme_whenRendered_thenLightOptionIsSelected() {
+        createSettingsScreen(uiState = SettingsUiState(themeMode = ThemeMode.LIGHT))
+        composeRule.onNodeWithTag(testTag = UiTestTag.settingsThemeOption("light"))
+            .assertIsSelected()
+    }
+
+    @Test
+    fun givenSystemTheme_whenRendered_thenSystemOptionIsSelected() {
+        createSettingsScreen(uiState = SettingsUiState(themeMode = ThemeMode.SYSTEM))
+        composeRule.onNodeWithTag(testTag = UiTestTag.settingsThemeOption("System"))
+            .assertIsSelected()
+    }
+
+    @Test
+    fun givenDarkTheme_whenRendered_thenDarkOptionIsSelected() {
+        createSettingsScreen(uiState = SettingsUiState(themeMode = ThemeMode.DARK))
+        composeRule.onNodeWithTag(testTag = UiTestTag.settingsThemeOption("Dark"))
+            .assertIsSelected()
+    }
+
+    @Test
+    fun givenSettingsRendered_whenBackClicked_thenEmitBackCallback() {
+        var backClicked = false
+
+        createSettingsScreen(
+            onBack = { backClicked = true }
+        )
+
+        composeRule.onNodeWithTag(testTag = TOP_APP_BAR).performClick()
+        assertTrue(backClicked)
+    }
+
+    @Test
+    fun givenInStockSwitchOff_whenClicked_thenEmitsTrue() {
+        var emitted: Boolean? = null
+
+        createSettingsScreen(
+            uiState = SettingsUiState(inStockOnly = false),
+            onInStockOnlyChange = { newState -> emitted = newState }
+        )
+
+        composeRule.onNodeWithTag(SETTINGS_IN_STOCK_SWITCH).performClick()
+
+        assertEquals(expected = true, actual = emitted)
+    }
+
+    @Test
+    fun givenLightTheme_whenDarkClicked_thenEmitsDarkTheme() {
+        var selectedTheme: ThemeMode? = null
+
+        createSettingsScreen(
+            uiState = SettingsUiState(themeMode = ThemeMode.LIGHT),
+            onThemeModeSelected = { newThemeMode -> selectedTheme = newThemeMode }
+        )
+
+        composeRule.onNodeWithTag(testTag = settingsThemeOption("dark")).performClick()
+
+        assertEquals(expected = ThemeMode.DARK, actual = selectedTheme)
     }
 
 }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/components/MarketTopAppBar.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/components/MarketTopAppBar.kt
@@ -11,7 +11,9 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.TOP_APP_BAR
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -31,6 +33,7 @@ fun MarketTopAppBar(
         },
         navigationIcon = {
             IconButton(
+                modifier = Modifier.testTag(TOP_APP_BAR),
                 onClick = {
                     onBackSelected()
                 }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/testing/UiTestTag.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/testing/UiTestTag.kt
@@ -1,0 +1,12 @@
+package com.amrubio27.cursotestingandroid.core.presentation.testing
+
+object UiTestTag {
+    const val TOP_APP_BAR = "top_app_bar"
+
+    //SETTINGS
+    const val SETTINGS_CONTENT = "settings_content"
+    const val SETTINGS_IN_STOCK_SWITCH = "settings_in_stock_switch"
+    const val SETTINGS_TAX_SWITCH = "settings_tax_switch"
+
+    fun settingsThemeOption(themeModeName: String) = "settings_theme_${themeModeName.lowercase()}"
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreen.kt
@@ -28,13 +28,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.amrubio27.cursotestingandroid.R
 import com.amrubio27.cursotestingandroid.core.domain.model.ThemeMode
 import com.amrubio27.cursotestingandroid.core.presentation.components.MarketTopAppBar
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.SETTINGS_CONTENT
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.SETTINGS_IN_STOCK_SWITCH
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.SETTINGS_TAX_SWITCH
 
 @Composable
 fun SettingsScreen(
@@ -52,22 +59,23 @@ fun SettingsScreen(
 
 }
 
-@Preview
+
 @Composable
 fun SettingsContent(
-    uiState: SettingsUiState = SettingsUiState(),
-    onBack: () -> Unit = {},
-    onInStockOnlyChange: (Boolean) -> Unit = {},
-    onThemeModeSelected: (ThemeMode) -> Unit = {}
+    uiState: SettingsUiState,
+    onBack: () -> Unit,
+    onInStockOnlyChange: (Boolean) -> Unit,
+    onThemeModeSelected: (ThemeMode) -> Unit
 ) {
     Scaffold(
         topBar = {
             MarketTopAppBar(
-                title = "Ajustes", onBackSelected = { onBack() })
+                title = stringResource(R.string.settings_title), onBackSelected = { onBack() })
         }) { paddingValues ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .testTag(SETTINGS_CONTENT)
                 .padding(paddingValues)
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
@@ -93,7 +101,7 @@ fun SettingsContent(
                         )
 
                         Text(
-                            "Filtros y visualización",
+                            stringResource(R.string.settings_filters_section),
                             style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.onSurface,
                             fontWeight = FontWeight.Bold
@@ -111,7 +119,7 @@ fun SettingsContent(
                             verticalArrangement = Arrangement.spacedBy(4.dp)
                         ) {
                             Text(
-                                "Solo productos en Stock",
+                                stringResource(R.string.settings_in_stock_only),
                                 style = MaterialTheme.typography.bodyLarge,
                                 fontWeight = FontWeight.Medium
                             )
@@ -124,7 +132,8 @@ fun SettingsContent(
 
                         Switch(
                             checked = uiState.inStockOnly,
-                            onCheckedChange = onInStockOnlyChange
+                            onCheckedChange = onInStockOnlyChange,
+                            modifier = Modifier.testTag(SETTINGS_IN_STOCK_SWITCH)
                         )
                     }
 
@@ -152,7 +161,8 @@ fun SettingsContent(
 
                         Switch(
                             checked = true,
-                            onCheckedChange = {}
+                            onCheckedChange = {},
+                            modifier = Modifier.testTag(SETTINGS_TAX_SWITCH)
                         )
                     }
                 }
@@ -193,7 +203,7 @@ fun SettingsContent(
                         verticalArrangement = Arrangement.spacedBy(4.dp)
                     ) {
                         Text(
-                            "Tema de la aplicación",
+                            stringResource(R.string.settings_theme_label),
                             style = MaterialTheme.typography.bodyLarge,
                             fontWeight = FontWeight.Medium
                         )
@@ -207,18 +217,21 @@ fun SettingsContent(
                             modifier = Modifier.fillMaxWidth()
                         ) {
                             SegmentedButton(
+                                modifier = Modifier.testTag(UiTestTag.settingsThemeOption("system")),
                                 shape = SegmentedButtonDefaults.itemShape(0, 3),
                                 onClick = { onThemeModeSelected(ThemeMode.SYSTEM) },
                                 selected = uiState.themeMode == ThemeMode.SYSTEM,
                                 label = { Text("Sistema") }
                             )
                             SegmentedButton(
+                                modifier = Modifier.testTag(UiTestTag.settingsThemeOption("light")),
                                 shape = SegmentedButtonDefaults.itemShape(1, 3),
                                 onClick = { onThemeModeSelected(ThemeMode.LIGHT) },
                                 selected = uiState.themeMode == ThemeMode.LIGHT,
                                 label = { Text("Claro") }
                             )
                             SegmentedButton(
+                                modifier = Modifier.testTag(UiTestTag.settingsThemeOption("dark")),
                                 shape = SegmentedButtonDefaults.itemShape(2, 3),
                                 onClick = { onThemeModeSelected(ThemeMode.DARK) },
                                 selected = uiState.themeMode == ThemeMode.DARK,
@@ -230,4 +243,15 @@ fun SettingsContent(
             }
         }
     }
+}
+
+@Preview
+@Composable
+fun SettingsContentPreview() {
+    SettingsContent(
+        uiState = SettingsUiState(),
+        onBack = {},
+        onThemeModeSelected = {},
+        onInStockOnlyChange = {}
+    )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,11 @@
 <resources>
     <string name="app_name">CursoTestingAndroid</string>
+
+    <!-- Settings -->
+    <string name="settings_title">Ajustes</string>
+    <string name="settings_filters_section">Filtros y visualización</string>
+    <string name="settings_in_stock_only">Solo productos en Stock</string>
+    <string name="settings_appearance_section">Apariencia</string>
+    <string name="settings_theme_label">Tema de la aplicación</string>
+
 </resources>


### PR DESCRIPTION
# 🧪 feat(testing): tests de UI para `SettingsScreen` y estandarización de `UiTestTag`

## 📌 Resumen

Esta PR añade tests de UI para la pantalla de ajustes (`SettingsScreen`) y refuerza la estrategia de testeo de componentes Compose mediante `testTag`s reutilizables.  
El objetivo es comprobar que la pantalla renderiza correctamente sus secciones, que los estados iniciales se muestran como corresponde y que las interacciones del usuario disparan los callbacks esperados.

Además, se introducen etiquetas de testing centralizadas en `UiTestTag.kt`, lo que mejora la mantenibilidad y evita duplicación de strings mágicos en los tests.

---

## 🎯 Objetivo de los cambios

El propósito de estos cambios es validar de forma clara y repetible que la pantalla de ajustes:

- muestra correctamente sus apartados visuales,
- refleja el estado de configuración en los controles,
- responde a las interacciones del usuario,
- y comunica correctamente los eventos a la capa de presentación.

Al tratarse de una pantalla Compose, los tests de UI tienen mucho valor porque verifican no solo la lógica, sino también el renderizado y el comportamiento observable del componente.

---

## 🧩 Problema que se resuelve

Antes de esta PR, la pantalla de ajustes podía depender de comprobaciones manuales o de validaciones menos precisas.  
Eso deja varios huecos:

- no se asegura que los textos visibles estén realmente presentes,
- no se valida que los switches y opciones aparezcan en el estado correcto,
- no se comprueba que al interactuar con la pantalla se llamen los callbacks adecuados,
- y los tests pueden volverse frágiles si usan selectores poco estables.

Con esta PR se cubre ese hueco mediante tests de Compose más robustos y legibles, apoyados en `UiTestTag`.

---

## ✨ Cambios principales

### 1. Nuevos tests de UI para `SettingsScreen`

Se añade `SettingsScreenTest.kt`, una suite de tests instrumentados que valida el comportamiento visual e interactivo de la pantalla.

#### ¿Qué se está comprobando?
- que el título y las secciones principales se renderizan,
- que el switch de “solo productos en stock” refleja el estado correcto,
- que el selector de tema marca la opción activa,
- que el botón de volver dispara el callback de navegación,
- y que al pulsar controles se emiten los valores esperados.

---

### 2. Centralización de `testTag`s en `UiTestTag.kt`

Se usa `UiTestTag` para dar identificadores estables a elementos importantes de la UI:

- `TOP_APP_BAR`
- `SETTINGS_CONTENT`
- `SETTINGS_IN_STOCK_SWITCH`
- `SETTINGS_TAX_SWITCH`
- `settingsThemeOption(themeModeName)`

Esto permite que los tests no dependan de textos frágiles o de jerarquías internas del árbol de Compose.

#### ¿Por qué es importante?
Porque los `testTag`s:
- hacen los tests más legibles,
- reducen la fragilidad,
- y separan la intención del test de detalles visuales que podrían cambiar.

---

### 3. Ajustes en `SettingsScreen.kt`

La pantalla se estructura en dos tarjetas principales:

#### Tarjeta 1: filtros y visualización
Contiene:
- el switch de “Solo productos en Stock”,
- el switch de “Mostrar impuestos incluidos”,
- el bloque de explicación visual para filtros.

#### Tarjeta 2: apariencia
Contiene:
- el selector segmentado del tema,
- con opciones `Sistema`, `Claro` y `Oscuro`.

#### ¿Qué aporta esto al test?
Esta estructura hace que la pantalla sea más predecible de validar con Compose:
- se pueden localizar bien los elementos,
- se pueden comprobar estados visuales,
- y se pueden testear callbacks concretos.

---

### 4. Ajuste de textos en `strings.xml`

Se centralizan textos clave de la pantalla como:
- `settings_title`
- `settings_filters_section`
- `settings_in_stock_only`
- `settings_appearance_section`
- `settings_theme_label`

#### ¿Por qué es relevante?
Porque el test de UI puede usar `getString(...)` y validar que los textos realmente están en pantalla.  
Esto aporta dos beneficios:

- el test comprueba la UI real tal como la ve el usuario,
- y se evita duplicar cadenas de texto en el propio test.

---

### 5. `MarketTopAppBar.kt` y test del botón de volver

El `TopAppBar` reutilizable coloca un `testTag` en el `IconButton` del botón de navegación:

```kotlin
modifier = Modifier.testTag(TOP_APP_BAR)
```

#### ¿Por qué?
Porque en Compose, localizar botones solo por estructura interna puede ser poco fiable.  
Con el `testTag`, el test puede interactuar directamente con el elemento de navegación y verificar que el callback `onBackSelected()` se ejecuta.

---

## 🧪 Explicación didáctica de los tests

Los tests de `SettingsScreenTest` no solo comprueban que “la pantalla se ve”, sino que validan escenarios concretos de la lógica visual y funcional de la pantalla.

### `firstUITest`
Comprueba que el título principal “Ajustes” aparece en pantalla.

#### ¿Por qué tiene sentido?
Porque es la comprobación más básica del renderizado:  
si la pantalla no muestra ni siquiera el encabezado, probablemente hay un problema de composición o navegación.

---

### `givenDefaultSettingsState_whenRendered_thenShowsFilterAndAppearanceSections`

Este test verifica que, partiendo del estado por defecto, la pantalla muestra:
- el título,
- la sección de filtros,
- la sección de apariencia,
- el switch de stock,
- el switch de impuestos,
- y el selector de tema.

#### ¿Por qué es importante?
Porque valida el contrato visual de la pantalla:  
cuando el `uiState` llega con valores por defecto, la UI debe reflejar correctamente esa configuración.

---

### `givenInStockOnlyFalse_whenRendered_thenSwitchIsOff`
Valida que, si el estado indica `inStockOnly = false`, el switch aparece apagado.

#### ¿Por qué tiene sentido?
Porque el control visual debe estar sincronizado con el estado del ViewModel.  
Si el estado dice “false”, el switch no puede mostrarse encendido.

---

### `givenInStockOnlyTrue_whenRendered_thenSwitchIsOn`
Valida lo contrario: si el estado es `true`, el switch aparece encendido.

#### ¿Por qué tiene sentido?
Porque confirma la bidireccionalidad del renderizado: el estado gobierna la UI.

---

### `givenLightTheme_whenRendered_thenLightOptionIsSelected`
Comprueba que, si el tema actual es `LIGHT`, la opción segmentada de “Claro” está seleccionada.

#### ¿Por qué tiene sentido?
Porque el selector de tema es una representación visual del estado y debe reflejar exactamente el modo activo.

---

### `givenSystemTheme_whenRendered_thenSystemOptionIsSelected`
Comprueba que el modo `SYSTEM` activa la opción “Sistema”.

#### ¿Por qué tiene sentido?
Porque valida la correspondencia entre el modelo de dominio `ThemeMode.SYSTEM` y su representación visual.

---

### `givenDarkTheme_whenRendered_thenDarkOptionIsSelected`
Comprueba que el modo `DARK` activa la opción “Oscuro”.

#### ¿Por qué tiene sentido?
Porque completa la cobertura de la lógica del selector de tema, asegurando que cada valor posible se representa correctamente.

---

### `givenSettingsRendered_whenBackClicked_thenEmitBackCallback`
Comprueba que al pulsar el botón de volver se ejecuta el callback `onBack`.

#### ¿Por qué tiene sentido?
Porque el botón de navegación no debe solo “verse”, sino producir el evento esperado.  
Este test valida la interacción y confirma que la pantalla puede notificar la acción de salida.

---

### `givenInStockSwitchOff_whenClicked_thenEmitsTrue`
Valida que, si el switch de stock está apagado y el usuario hace clic, el callback recibe `true`.

#### ¿Por qué tiene sentido?
Porque el control debe emitir el nuevo valor correcto al cambiar su estado.  
Este test verifica la interacción real del usuario con el switch.

---

### `givenLightTheme_whenDarkClicked_thenEmitsDarkTheme`
Comprueba que, estando en modo claro, al pulsar la opción “Oscuro” se emite `ThemeMode.DARK`.

#### ¿Por qué tiene sentido?
Porque el selector de tema no solo debe reflejar el estado actual, sino también comunicar correctamente el nuevo valor al hacer una selección distinta.

---

## 🔍 Relación con la lógica de `SettingsScreen`

`SettingsScreen` está planteada como una pantalla de presentación con estado controlado por `SettingsViewModel`.  
Eso significa que:

- la UI no guarda el estado de forma local,
- renderiza lo que recibe en `SettingsUiState`,
- y emite acciones hacia el ViewModel mediante callbacks.

Los tests encajan muy bien con esta arquitectura porque verifican justo esas dos cosas:
1. renderizado correcto según el estado,
2. emisión correcta de eventos ante interacción.

---

## 🧠 Buenas prácticas aplicadas

### 1. Separación entre UI y lógica
`SettingsContent` recibe datos y callbacks, lo que facilita probarla directamente sin necesidad de levantar toda la app.

### 2. Uso de `testTag`
Hace los tests más robustos y evita depender de detalles visuales frágiles.

### 3. Textos centralizados
Permiten mantener la UI y los tests sincronizados con `strings.xml`.

### 4. Cobertura de renderizado e interacción
Los tests no se quedan solo en “se ve”, sino que también validan “responde correctamente”.

---

## 📁 Archivos implicados

### Modificados
- `app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreen.kt`
- `app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/testing/UiTestTag.kt`
- `app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/components/MarketTopAppBar.kt`
- `app/src/main/res/values/strings.xml`

### Añadidos
- `app/src/androidTest/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreenTest.kt`

---

## ✅ Beneficios de esta PR

- Valida el renderizado real de la pantalla de ajustes.
- Comprueba la interacción de la UI con callbacks.
- Hace los tests más robustos con `testTag`s reutilizables.
- Mejora la mantenibilidad al centralizar identificadores y textos.
- Sirve como documentación viva del comportamiento esperado de la pantalla.

---

## 📝 Notas finales

Esta PR no solo añade tests: también refuerza la forma de testear Compose en el proyecto.  
Los `testTag`s, la estructura clara de `SettingsContent` y la centralización de textos ayudan a que la pantalla sea más fácil de mantener, probar y documentar.

En conjunto, estos cambios convierten la pantalla de ajustes en un ejemplo claro de cómo validar una UI Compose tanto en su parte visual como en su comportamiento interactivo.
```