### PR TITLE
Implement UI tests and infrastructure for the product list screen

### DIFF
--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreenTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreenTest.kt
@@ -1,11 +1,21 @@
 package com.amrubio27.cursotestingandroid.productlist.presentation
 
 import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import com.amrubio27.cursotestingandroid.core.mothers.ProductMother.bread
+import com.amrubio27.cursotestingandroid.core.mothers.ProductMother.coffee
+import com.amrubio27.cursotestingandroid.core.mothers.ProductMother.milk
 import com.amrubio27.cursotestingandroid.core.mothers.uistate.ProductListUiStateMother
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.FILTER_VIEW
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.PRODUCT_LIST_LOADING
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.productListItem
 import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductWithPromotion
 import com.amrubio27.cursotestingandroid.productlist.domain.model.SortOption
 import org.junit.Rule
+import kotlin.test.Test
 
 class ProductListScreenTest {
     @get:Rule
@@ -36,4 +46,47 @@ class ProductListScreenTest {
             )
         }
     }
+
+    @Test
+    fun givenLoadingState_whenRendered_thenShowsProgressView() {
+        createProductListScreen(uiState = ProductListUiState.Loading)
+
+        composeRule.onNodeWithTag(testTag = PRODUCT_LIST_LOADING).assertIsDisplayed()
+    }
+
+    @Test
+    fun givenErrorState_whenRendered_thenShowsErrorMessage() {
+        createProductListScreen(uiState = ProductListUiState.Error(""))
+
+        composeRule.onNodeWithText("ERROR").assertIsDisplayed()
+    }
+
+    @Test
+    fun givenSuccessState_whenRendered_thenShowsProductsAndCount() {
+        createProductListScreen(uiState = ProductListUiStateMother.success())
+
+        composeRule.onNodeWithText("3 productos").assertIsDisplayed()
+        composeRule.onNodeWithTag(testTag = FILTER_VIEW).assertIsDisplayed()
+
+        composeRule.onNodeWithTag(testTag = productListItem(productId = coffee().id))
+            .assertIsDisplayed()
+        composeRule.onNodeWithTag(testTag = productListItem(productId = bread().id))
+            .assertIsDisplayed()
+        composeRule.onNodeWithTag(testTag = productListItem(productId = milk().id))
+            .assertIsDisplayed()
+
+        //Como apunte si necesitamos hacer scroll por que no se vean los items
+        //composeRule.onNodeWithTag(testTag = PRODUCT_LIST_LIST).performScrollToIndex
+        //composeRule.onNodeWithTag(testTag = PRODUCT_LIST_LIST).performScrollToNode(hasTestTag(productListItem("1234556")))
+
+        //composeRule.onNodeWithTag(testTag = productListItem("1234556")).assertIsDisplayed()
+    }
+
+    @Test
+    fun givenSuccessState_whenRendered_thenShowsEmptyMessage() {
+        createProductListScreen(uiState = ProductListUiStateMother.success(products = emptyList()))
+
+        composeRule.onNodeWithText("No se encontraron productos").assertIsDisplayed()
+    }
+
 }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/testing/UiTestTag.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/testing/UiTestTag.kt
@@ -2,6 +2,7 @@ package com.amrubio27.cursotestingandroid.core.presentation.testing
 
 object UiTestTag {
     const val TOP_APP_BAR = "top_app_bar"
+    const val FILTER_VIEW = "filter_view"
 
     //SETTINGS
     const val SETTINGS_CONTENT = "settings_content"
@@ -9,4 +10,9 @@ object UiTestTag {
     const val SETTINGS_TAX_SWITCH = "settings_tax_switch"
 
     fun settingsThemeOption(themeModeName: String) = "settings_theme_${themeModeName.lowercase()}"
+
+    // PRODUCT LIST
+    const val PRODUCT_LIST_LOADING = "product_list_loading"
+    const val PRODUCT_LIST_LIST = "product_list_list"
+    fun productListItem(productId: String) = "product_list_item_$productId"
 }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreen.kt
@@ -25,12 +25,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.amrubio27.cursotestingandroid.cart.presentation.CartUiState
 import com.amrubio27.cursotestingandroid.cart.presentation.CartViewModel
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.PRODUCT_LIST_LIST
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.PRODUCT_LIST_LOADING
 import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductWithPromotion
 import com.amrubio27.cursotestingandroid.productlist.domain.model.SortOption
 import com.amrubio27.cursotestingandroid.productlist.presentation.components.FiltersMenu
@@ -121,7 +124,7 @@ fun ProductListContent(
                         .padding(paddingValues),
                     contentAlignment = Alignment.Center
                 ) {
-                    CircularProgressIndicator()
+                    CircularProgressIndicator(modifier = Modifier.testTag(PRODUCT_LIST_LOADING))
                 }
             }
 
@@ -185,7 +188,9 @@ fun ProductListContent(
                             }
                         }
                     } else {
-                        LazyColumn {
+                        LazyColumn(
+                            modifier = Modifier.testTag(PRODUCT_LIST_LIST)
+                        ) {
                             items(uiState.products) { item: ProductWithPromotion ->
                                 ProductItem(
                                     item = item,

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/FiltersMenu.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/FiltersMenu.kt
@@ -15,7 +15,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.FILTER_VIEW
 import com.amrubio27.cursotestingandroid.productlist.domain.model.SortOption
 import com.amrubio27.cursotestingandroid.productlist.presentation.ProductListUiState
 
@@ -29,6 +31,7 @@ fun FiltersMenu(
     Card(
         modifier = modifier
             .fillMaxWidth()
+            .testTag(FILTER_VIEW)
             .padding(horizontal = 16.dp, vertical = 8.dp),
         elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/ProductItem.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/ProductItem.kt
@@ -22,11 +22,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.productListItem
 import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductPromotion
 import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductWithPromotion
 import java.util.Locale
@@ -48,6 +50,7 @@ fun ProductItem(
     Card(
         modifier = Modifier
             .fillMaxWidth()
+            .testTag(productListItem(product.id))
             .padding(start = 16.dp, end = 16.dp, top = 16.dp)
             .clickable { onClick(item) },
         elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),

--- a/app/src/sharedTest/java/com/amrubio27/cursotestingandroid/core/mothers/uistate/ProductListUiStateMother.kt
+++ b/app/src/sharedTest/java/com/amrubio27/cursotestingandroid/core/mothers/uistate/ProductListUiStateMother.kt
@@ -12,6 +12,10 @@ object ProductListUiStateMother {
             ProductWithPromotion(ProductMother.coffee(), PromotionMother.percent()),
             ProductWithPromotion(ProductMother.bread()),
             ProductWithPromotion(ProductMother.milk()),
+            /*ProductWithPromotion(product {withId("123")}),
+            ProductWithPromotion(product {withId("1234")}),
+            ProductWithPromotion(product {withId("12345")}),
+            ProductWithPromotion(product {withId("1234556")}),*/
         ),
         categories: List<String> = listOf("bread", "drinks", "lacteo"),
         selectedCategory: String? = null,


### PR DESCRIPTION
# 🧪 feat(testing): centralización de `UiTestTag`, base de UI test para `ProductListScreen` y estrategia contra flakes en `LazyColumn`

## 📌 Resumen

Esta PR introduce y documenta cambios centrados en mejorar la testabilidad UI de la pantalla de producto:

- centraliza identificadores de test (`UiTestTag`) para evitar "strings mágicos" en tests,
- prepara `ProductListScreenTest` usando objetos madre (`ProductListUiStateMother`) para generar estados de UI coherentes y reutilizables,
- y documenta/practica soluciones a un problema real de tests UI con listas perezosas (`LazyColumn`): elementos que no están en pantalla aún no son compuestos y los tests fallan por no encontrarlos.

La PR no solo aplica cambios de código, también explica el porqué técnico, muestra patrones (Builders / Mothers) y ofrece tácticas prácticas para hacer tests UI robustos frente a listas grandes y scrolling.

---

## 🎯 Objetivos

- Hacer los tests UI más estables y legibles.
- Facilitar la localización de nodos desde tests por medio de `testTag`s centralizados.
- Evitar flakes relacionados con `LazyColumn` (elementos fuera de pantalla).
- Proveer una guía didáctica y ejemplos para que el equipo repita este patrón en futuros commits.

---

## 🧩 Archivos modificados / añadidos (contexto del commit)

- `app/src/main/java/.../core/presentation/testing/UiTestTag.kt`  
  - Centraliza `testTag`s. (ya añadido)
- `app/src/androidTest/java/.../productlist/presentation/ProductListScreenTest.kt`  
  - Base del test UI para `ProductListContent`, ahora usando `ProductListUiStateMother`.
- `app/src/main/java/.../productlist/presentation/ProductListScreen.kt`  
  - (no se edición obligatoria, pero se recomienda) añadir `testTag` a `LazyColumn` y a cada `ProductItem` para tests.
- `app/src/sharedTest/java/.../core/mothers/*` y builders  
  - Usados por los tests para generar `uiState` (ya presentes en el commit).

---

## ✨ Cambios principales y su razón técnica

1) Centralizar `testTag`s en `UiTestTag`  
   - Qué: `UiTestTag` contiene constantes y helpers (p. ej. `settingsThemeOption(name)`).
   - Por qué: evita duplicación y errores por typo en tests instrumentados; mejora mantenibilidad.
   - Beneficio: si cambia un `testTag`, se actualiza en un único lugar.

2) `ProductListScreenTest` usando `ProductListUiStateMother`  
   - Qué: el test crea la UI con estados preconstruidos (`ProductListUiStateMother.success()`), lo que evita montar manualmente listas largas o datos inconsistentes.
   - Por qué: tests más legibles y deterministas; evita ruido de creación de datos en el test.
   - Beneficio: tests sirven también como documentación del estado esperado.

3) Recomendación práctica: añadir `testTag`s a la lista y a los items  
   - Qué (recomendado): en `ProductListScreen`/`ProductItem` añadir:
     - tag al `LazyColumn` (p. ej. `UiTestTag.PRODUCT_LIST`)
     - tag por producto: `UiTestTag.productItem(productId)` (función helper)
   - Por qué: permite localizar y hacer scroll hasta items concretos sin depender solo de texto visible.
   - Beneficio: reduce flakes por items fuera de pantalla.

---

## 🧪 Problema real (nota de la clase) — Qué ocurre y por qué falla el test

NOTA IMPORTANTE (resumida):
- En UI tests, si renderizas una lista larga en `LazyColumn`, muchos items quedan fuera de pantalla y no se componen aún (optimización del LazyList). Si el test busca un item que todavía no fue compuesto, falla.
- Scroll manual puede funcionar en algunos casos pero es frágil con `LazyColumn`.
- Estrategias: hacer scroll incremental, asignar tags a la lista y a cada item para hacer scroll hacia el nodo objetivo, o buscar activamente y repetir scroll hasta que aparezca.

Esto explica por qué tests UI que funcionan en una ejecución local pueden fallar en CI / dispositivo real: la composición perezosa y diferencias en el viewport.

---

## ✅ Estrategias recomendadas (robustas) para tests UI con `LazyColumn`

A continuación explico varias soluciones con ejemplos y trade-offs. Elige la que mejor se adapte a tu caso.

### Estrategia A — Taggea cada item y usa `performScrollTo()` sobre el nodo objetivo
1. En `ProductItem` añade un tag único:
```kotlin
// dentro de ProductItem composable (o en la llamada)
Box(modifier = Modifier.testTag(UiTestTag.productItem(item.product.id))) {
    // contenido...
}
```
2. En `ProductListScreen` añade tag a la `LazyColumn` (opcional pero útil):
```kotlin
LazyColumn(modifier = Modifier.testTag(UiTestTag.PRODUCT_LIST)) {
    items(uiState.products) { item -> ... }
}
```
3. En el test, localiza el nodo por tag y pide scroll hasta él:
```kotlin
val targetTag = UiTestTag.productItem("id-coffee")
composeRule.onNodeWithTag(targetTag).performScrollTo()
composeRule.onNodeWithTag(targetTag).assertIsDisplayed()
```
- Por qué funciona: `performScrollTo()` intenta desplazar la vista hasta que el nodo pueda ser compuesto/ubicado en el viewport.
- Nota: `performScrollTo()` puede lanzar si el nodo no existe. Conviene usar `waitUntil`/reintentos o asegurar que el test data tiene el id buscado (ver Estrategia C).

### Estrategia B — Scroll por índice (cuando sea posible)
Si creas items con índices conocidos, y tu environment de test provee extensiones, puedes usar un helper para scroll por índice. Ejemplo conceptual:
```kotlin
composeRule.onNodeWithTag(UiTestTag.PRODUCT_LIST)
    .performScrollToIndex(index = lastIndex)
```
- Advertencia: `performScrollToIndex` no siempre está presente en todas las versiones de testing; usar solo si tu versión de Compose Test la soporta o si implementas helper (ver docs).

### Estrategia C — Limitar datos en tests (la solución más simple y robusta)
En tests unitarios/instrumentados que no necesitan validar scroll, crea un `uiState` con pocos items (por ejemplo 3) usando `ProductListUiStateMother.success()` y no habrá problema de viewport:
```kotlin
createProductListScreen(uiState = ProductListUiStateMother.success(products = listOf(...)))
```
- Ventaja: evita la complejidad del scroll en la mayor parte de tests.
- Uso recomendado: cuando el test valida render o interacción con el primer bloque de la lista.

### Estrategia D — Reintentos activos / loop de scroll hasta aparecer
Implementa un helper de test que intente:
- buscar el nodo por tag
- si no existe: realizar scroll incremental sobre la lista y volver a buscar
- repetir hasta timeout
Pseudo-código:
```kotlin
fun scrollToNodeWithTagOrFail(tag: String, maxAttempts = 10) {
    repeat(maxAttempts) {
        try {
            composeRule.onNodeWithTag(tag).performScrollTo()
            return
        } catch (e: Exception) {
            composeRule.onNodeWithTag(UiTestTag.PRODUCT_LIST).performScrollTo() // intento genérico
            composeRule.waitForIdle()
        }
    }
    error("No se encontró nodo $tag después de $maxAttempts intentos")
}
```
- Es más robusto pero más código de soporte.

### Estrategia E — Añadir `testTag`s también en contenido dentro del item
A veces el nodo del item no es el que tiene `testTag` (por ejemplo la card interna). Añade un `testTag` en el contenedor visible (título, imagen) para facilitar busqueda por contenido.

---

## 🧰 Ejemplos concretos (código para aplicar en tu repo)

1) Añadir helper en `UiTestTag.kt`:
```kotlin
object UiTestTag {
    const val PRODUCT_LIST = "product_list"
    fun productItem(productId: String) = "product_item_$productId"
    // ... otras etiquetas existentes
}
```

2) Taggear `LazyColumn` y `ProductItem` (en `ProductListScreen` / `ProductItem`):
```kotlin
LazyColumn(modifier = Modifier.testTag(UiTestTag.PRODUCT_LIST)) {
    items(uiState.products) { item ->
        ProductItem(
            item = item,
            onClick = onProductSelected,
            modifier = Modifier.testTag(UiTestTag.productItem(item.product.id))
        )
    }
}
```
(si `ProductItem` no expone modifier, pásalo o modifica la firma).

3) Test ejemplo con scroll seguro:
```kotlin
@Test
fun givenSuccess_whenClickLastProduct_thenNavigate() {
    val lastProductId = "id-coffee"
    createProductListScreen(uiState = ProductListUiStateMother.success(), filterVisible = false)

    // intenta scroll y comprobación
    composeRule.onNodeWithTag(UiTestTag.productItem(lastProductId))
        .performScrollTo() // intenta desplazar hasta el nodo
    composeRule.onNodeWithTag(UiTestTag.productItem(lastProductId)).assertIsDisplayed()

    // Interacción
    composeRule.onNodeWithTag(UiTestTag.productItem(lastProductId)).performClick()
    // ... assert navegación / callback
}
```

4) Si prefieres limitar datos en tests (ProductListUiStateMother flexible):
```kotlin
val singleProductState = ProductListUiStateMother.success(
    products = listOf(ProductWithPromotion(ProductMother.coffee()))
)
createProductListScreen(uiState = singleProductState)
composeRule.onNodeWithText("Café").assertIsDisplayed()
```

---

## 🧠 Buenas prácticas complementarias para tests UI con Compose

- Desactivar animaciones en tests (puede producir flakes). En Compose TestRule:
  - `composeRule.mainClock.autoAdvance = true/false` o ajustar `mainClock.advanceUntilIdle()` según necesidades.
- Usar `composeRule.waitForIdle()` o `composeRule.mainClock.advanceUntilIdle()` después de acciones que disparan recomposition.
- Preferir `testTag`s estables en lugar de `onNodeWithText` para localizar nodos (texto puede cambiar y ser i18n).
- Mantener los `uiState` de los tests simples: solo los datos necesarios para el escenario.
- Añadir logs de debug con `composeRule.onRoot().printToLog("TAG")` cuando un test falla para inspeccionar árbol semántico.
- En CI, ejecutar tests en un AVD con suficiente resolución para evitar problemas de viewport extremos.

---

## ⚠️ Riesgos / limitaciones

- `performScrollTo()` puede depender de versiones de Compose Test; si tu versión no expone esta acción, usa estrategias de reintento (E) o limita dataset (C).
- Taggear internamente `ProductItem` requiere cambiar su API (exponer `modifier`), lo cual es un pequeño cambio en la vista.
- Añadir tags a todos los items incrementa la superficie semántica, pero ese coste se compensa con tests estables.

---

## 🔜 Recomendaciones y próximos pasos concretos (priorizados)

1. **Añadir tags**: implementar `UiTestTag.productItem(...)` y taggear `LazyColumn` y `ProductItem`. (Alta prioridad)
2. **Ampliar `ProductListUiStateMother`** con variantes pequeñas (1 producto), medias (3), y largas (>20) para testing rápido y pruebas de stress. (Medio)
3. **Implementar helpers de test**: `scrollToNodeWithTagOrFail(tag)` en `sharedTest` para encapsular reintentos. (Medio)
4. **Escribir tests concretos** en `ProductListScreenTest` que cubran:
   - renderizado en `Loading/Error/Success`
   - interacción con item visible (sin scroll)
   - interacción con item fuera de viewport (usar helper)  
   (Alta)
5. **Documentar** en README de testing las reglas: cuándo usar tags, cuándo limitar datos, cómo hacer scroll seguro. (Baja)

---

## ✅ Conclusión

Los cambios en `UiTestTag` y la base de `ProductListScreenTest` hacen la infraestructura de testing mucho más sólida y explicativa. Para evitar flakes típicos con `LazyColumn`, la recomendación práctica es:

- taggear el `LazyColumn` y cada `ProductItem`,
- usar `performScrollTo()` o helpers de reintento,
- y, cuando no se necesite probar scrolling, usar `ProductListUiStateMother` para crear estados con pocas entradas.

Con esto tu suite de UI tests será más confiable, fácil de mantener y servirá como documentación viva del comportamiento de la pantalla.

---