### PR TITLE
Implement UI tests for `HomeTopAppBar` interactions

### DIFF
--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreenTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import com.amrubio27.cursotestingandroid.core.mothers.ProductMother.bread
 import com.amrubio27.cursotestingandroid.core.mothers.ProductMother.coffee
 import com.amrubio27.cursotestingandroid.core.mothers.ProductMother.milk
@@ -13,11 +14,16 @@ import com.amrubio27.cursotestingandroid.core.mothers.uistate.ProductListUiState
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.FILTER_VIEW
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.PRODUCT_LIST_LOADING
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.TOP_APP_BAR_BADGE
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.TOP_APP_BAR_CART
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.TOP_APP_BAR_FILTER
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.TOP_APP_BAR_SETTINGS
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.productListCategory
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.productListItem
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.productListSortOption
 import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductWithPromotion
 import com.amrubio27.cursotestingandroid.productlist.domain.model.SortOption
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
 import org.junit.Rule
 import kotlin.test.Test
 
@@ -163,6 +169,47 @@ class ProductListScreenTest {
         composeRule.onNodeWithTag(testTag = TOP_APP_BAR_BADGE).assertIsDisplayed()
         composeRule.onNodeWithText("99+").assertIsDisplayed()
     }
+
+    @Test
+    fun givenFiltersVisible_whenToggleClicked_thenEmitFalse() {
+        var emitted: Boolean? = null
+        createProductListScreen(
+            filterVisible = true,
+            onFilterSelected = { emitted = it })
+
+        composeRule.onNodeWithTag(TOP_APP_BAR_FILTER).performClick()
+        assertEquals(false, emitted)
+    }
+
+    @Test
+    fun givenFiltersHidden_whenToggleClicked_thenEmitTrue() {
+        var emitted: Boolean? = null
+        createProductListScreen(
+            filterVisible = false,
+            onFilterSelected = { emitted = it })
+
+        composeRule.onNodeWithTag(testTag = TOP_APP_BAR_FILTER).performClick()
+        assertEquals(true, emitted)
+    }
+
+    @Test
+    fun givenProductListRendered_whenSettingsIconClicked_thenEmitCallback() {
+        var settingClicked = false
+        createProductListScreen(onSettingsSelected = { settingClicked = true })
+
+        composeRule.onNodeWithTag(testTag = TOP_APP_BAR_SETTINGS).performClick()
+        assertTrue(settingClicked)
+    }
+
+    @Test
+    fun givenProductListRendered_whenCartIconClicked_thenEmitCallback() {
+        var cartClicked = false
+        createProductListScreen(onCartSelected = { cartClicked = true })
+
+        composeRule.onNodeWithTag(testTag = TOP_APP_BAR_CART).performClick()
+        assertTrue(cartClicked)
+    }
+
 
 
 

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/testing/UiTestTag.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/testing/UiTestTag.kt
@@ -3,8 +3,13 @@ package com.amrubio27.cursotestingandroid.core.presentation.testing
 import com.amrubio27.cursotestingandroid.productlist.domain.model.SortOption
 
 object UiTestTag {
+
+    //TOP APP BAR
     const val TOP_APP_BAR = "top_app_bar"
     const val TOP_APP_BAR_BADGE = "top_app_bar_badge"
+    const val TOP_APP_BAR_FILTER = "top_app_bar_filter"
+    const val TOP_APP_BAR_SETTINGS = "top_app_bar_settings"
+    const val TOP_APP_BAR_CART = "top_app_bar_cart"
     const val FILTER_VIEW = "filter_view"
 
     //SETTINGS

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/HomeTopAppBar.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/HomeTopAppBar.kt
@@ -20,6 +20,9 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.unit.dp
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.TOP_APP_BAR_BADGE
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.TOP_APP_BAR_CART
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.TOP_APP_BAR_FILTER
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.TOP_APP_BAR_SETTINGS
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -45,6 +48,7 @@ fun HomeTopAppBar(
         ),
         actions = {
             IconButton(
+                modifier = Modifier.testTag(TOP_APP_BAR_FILTER),
                 onClick = { onFilterSelected(!filtersVisible) }
             ) {
                 Icon(
@@ -54,6 +58,7 @@ fun HomeTopAppBar(
                 )
             }
             IconButton(
+                modifier = Modifier.testTag(TOP_APP_BAR_SETTINGS),
                 onClick = { onSettingsSelected() }
             ) {
                 Icon(
@@ -75,7 +80,9 @@ fun HomeTopAppBar(
                     }
                 }
             }) {
-                IconButton(onClick = { onCartSelected() }) {
+                IconButton(
+                    modifier = Modifier.testTag(TOP_APP_BAR_CART),
+                    onClick = { onCartSelected() }) {
                     Icon(
                         imageVector = Icons.Default.ShoppingCart,
                         contentDescription = null,


### PR DESCRIPTION
# 🧪 test(ui): cobertura de callbacks en `HomeTopAppBar` desde `ProductListScreenTest`

## 📌 Resumen

Esta PR se centra exclusivamente en el testeo de interacción de los botones de la `HomeTopAppBar` de la pantalla de productos.  
Se validan cuatro comportamientos críticos:

1. el botón de filtros emite `false` cuando estaban visibles,
2. el botón de filtros emite `true` cuando estaban ocultos,
3. el botón de ajustes dispara su callback,
4. el botón de carrito dispara su callback.

El objetivo no es probar navegación real, sino verificar que la UI emite correctamente los eventos esperados al pulsar cada `IconButton`.

---

## 🎯 Objetivo de estos tests

Asegurar que la top bar cumple su contrato de interacción:

- `onFilterSelected(!filtersVisible)`
- `onSettingsSelected()`
- `onCartSelected()`

Es decir, que los botones no solo se renderizan, sino que **ejecutan la acción correcta** cuando el usuario interactúa.

---

## 🧩 Problema que se resuelve

En UI tests es común validar solo renderizado (`assertIsDisplayed`) y dejar sin cubrir la parte más importante: el evento de click.  
Sin estos tests, pueden colarse regresiones como:

- botón visible pero con `onClick` mal cableado,
- callback incorrecto para un botón,
- lógica de toggle invertida o rota.

Estos casos no se detectan viendo la UI: se detectan testando callbacks.

---

## ✨ Alcance exacto de esta PR

### Archivo implicado
- `app/src/androidTest/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreenTest.kt`

### Tests cubiertos (foco de esta PR)
- `givenFiltersVisible_whenToggleClicked_thenEmitFalse`
- `givenFiltersHidden_whenToggleClicked_thenEmitTrue`
- `givenProductListRendered_whenSettingsIconClicked_thenEmitCallback`
- `givenProductListRendered_whenCartIconClicked_thenEmitCallback`

---

## 🧪 Explicación didáctica de cada test (por qué tiene sentido)

### 1) `givenFiltersVisible_whenToggleClicked_thenEmitFalse`

```kotlin
@Test
fun givenFiltersVisible_whenToggleClicked_thenEmitFalse() {
    var emitted: Boolean? = null
    createProductListScreen(
        filterVisible = true,
        onFilterSelected = { emitted = it })

    composeRule.onNodeWithTag(TOP_APP_BAR_FILTER).performClick()
    assertEquals(false, emitted)
}
```

#### ¿Qué valida?
Valida la lógica de toggle cuando los filtros están visibles.

#### ¿Por qué tiene sentido según la lógica de la clase?
En `HomeTopAppBar`, el botón de filtros usa:

```kotlin
onClick = { onFilterSelected(!filtersVisible) }
```

Si `filtersVisible = true`, entonces `!filtersVisible = false`.  
Este test prueba exactamente esa rama lógica.

#### Riesgo que previene
Evita errores tipo:
- “Siempre emite true”
- “Siempre emite false”
- “No invierte el estado”

---

### 2) `givenFiltersHidden_whenToggleClicked_thenEmitTrue`

```kotlin
@Test
fun givenFiltersHidden_whenToggleClicked_thenEmitTrue() {
    var emitted: Boolean? = null
    createProductListScreen(
        filterVisible = false,
        onFilterSelected = { emitted = it })

    composeRule.onNodeWithTag(testTag = TOP_APP_BAR_FILTER).performClick()
    assertEquals(true, emitted)
}
```

#### ¿Qué valida?
La rama opuesta del toggle.

#### ¿Por qué tiene sentido?
Completa la cobertura del comportamiento binario del botón de filtros:
- caso A: true -> false
- caso B: false -> true

Solo con ambos casos tienes garantía real de que el toggle está bien implementado.

#### Valor didáctico
Muestra un principio importante de testing:  
**si un comportamiento tiene dos ramas, testea las dos**.

---

### 3) `givenProductListRendered_whenSettingsIconClicked_thenEmitCallback`

```kotlin
@Test
fun givenProductListRendered_whenSettingsIconClicked_thenEmitCallback() {
    var settingClicked = false
    createProductListScreen(onSettingsSelected = { settingClicked = true })

    composeRule.onNodeWithTag(testTag = TOP_APP_BAR_SETTINGS).performClick()
    assertTrue(settingClicked)
}
```

#### ¿Qué valida?
Que el botón de ajustes dispara `onSettingsSelected`.

#### ¿Por qué tiene sentido según la lógica de la clase?
La top bar actúa como capa de UI, no navega por sí misma.  
Su responsabilidad es emitir el callback para que la capa superior decida la navegación.

Este test valida exactamente ese contrato de diseño.

#### Riesgo que previene
Evita bugs como:
- botón de ajustes no hace nada al tocarlo,
- callback equivocado asignado,
- `onClick` eliminado en refactor.

---

### 4) `givenProductListRendered_whenCartIconClicked_thenEmitCallback`

```kotlin
@Test
fun givenProductListRendered_whenCartIconClicked_thenEmitCallback() {
    var cartClicked = false
    createProductListScreen(onCartSelected = { cartClicked = true })

    composeRule.onNodeWithTag(testTag = TOP_APP_BAR_CART).performClick()
    assertTrue(cartClicked)
}
```

#### ¿Qué valida?
Que el botón de carrito emite `onCartSelected`.

#### ¿Por qué tiene sentido?
Misma filosofía que en ajustes: la top bar emite evento; la navegación la decide otra capa.

#### Valor funcional
Este botón es crítico en la experiencia de compra; si falla el callback, el usuario no puede abrir el carrito.

---

## 🏗️ Relación con `UiTestTag` (por qué estos tests son robustos)

Estos tests dependen de tags semánticos (`TOP_APP_BAR_FILTER`, `TOP_APP_BAR_SETTINGS`, `TOP_APP_BAR_CART`) en vez de texto o posición visual.

### Beneficios de esa decisión
- No se rompen por cambios de copy o idioma.
- No se rompen si se reorganiza visualmente la top bar.
- Son más legibles: el selector del test dice exactamente qué elemento testea.

Esto convierte los tests en documentación viva del contrato de interacción.

---

## ✅ Qué garantiza esta PR al equipo

Con estos 4 tests, el equipo gana garantías concretas:

1. El botón de filtros invierte correctamente el estado.
2. El botón de ajustes emite evento.
3. El botón de carrito emite evento.
4. Refactors futuros en `HomeTopAppBar` no romperán silenciosamente el wiring de callbacks.

---

## 📚 Aprendizaje clave (como apunte de módulo)

Este bloque de tests enseña una práctica esencial en Compose UI testing:

- **No basta con testear renderizado**
- Hay que testear también **eventos de interacción** (`performClick` + assert de callback)

La top bar es un excelente ejemplo:
- visualmente puede verse perfecta,
- pero si no emite callbacks, funcionalmente está rota.

---

## 🔜 Próximo paso recomendado (natural)

Como evolución, se puede añadir un test extra para verificar que:
- al clickar `TOP_APP_BAR_FILTER`, además de emitir callback, cambia el estado de visibilidad en un escenario integrado (`ProductListScreen` + ViewModel fake).

Eso cerraría el ciclo completo:  
**click → callback → cambio de estado → cambio visible en UI**.

---

## Conclusión

Esta PR, enfocada en los tests señalados, mejora la fiabilidad de `HomeTopAppBar` en su aspecto más importante: la interacción.  
Los cuatro tests validan el contrato real de los `IconButton` y aseguran que la UI no solo se ve bien, sino que también responde correctamente a las acciones del usuario.