### PR TITLE
Implement instrumented tests for CartScreen and refactor for testability

### DIFF
--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/cart/presentation/CartScreenTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/cart/presentation/CartScreenTest.kt
@@ -1,0 +1,88 @@
+package com.amrubio27.cursotestingandroid.cart.presentation
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.CART_EMPTY
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.CART_LOADING
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.CART_RETRY
+import junit.framework.TestCase.assertTrue
+import org.junit.Rule
+import kotlin.test.Test
+
+class CartScreenTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun createCartScreen(
+        state: CartUiState,
+        onBack: () -> Unit = {},
+        onRetrySelected: () -> Unit = {},
+        onIncreaseQuantity: (String, Int) -> Unit = { _, _ -> },
+        onDecreaseQuantity: (String, Int) -> Unit = { _, _ -> },
+        onRemove: (String) -> Unit = {}
+    ) {
+        composeRule.setContent {
+            CartContent(
+                uiState = state,
+                onBack = onBack,
+                onRetrySelected = onRetrySelected,
+                onRemove = onRemove,
+                onDecreaseQuantity = onDecreaseQuantity,
+                onIncreaseQuantity = onIncreaseQuantity
+            )
+        }
+    }
+
+    @Test
+    fun givenLoadingState_whenRendered_thenShowProgressView() {
+        createCartScreen(state = CartUiState.Loading)
+
+        composeRule.onNodeWithTag(testTag = CART_LOADING).assertIsDisplayed()
+    }
+
+    @Test
+    fun givenErrorState_whenRendered_thenShowTextAndRetryButton() {
+        val errorText = "Prueba error"
+        createCartScreen(state = CartUiState.Error(errorText))
+
+        composeRule.onNodeWithText(errorText, substring = true, ignoreCase = true)
+            .assertIsDisplayed()
+        composeRule.onNodeWithText("Reintentar").assertIsDisplayed()
+    }
+
+    @Test
+    fun givenErrorState_whenRetryClicked_thenEmitsRetryCallback() {
+        var retryClicked: Boolean = false
+
+        val errorText = "Prueba error"
+        createCartScreen(
+            state = CartUiState.Error(errorText),
+            onRetrySelected = { retryClicked = true }
+        )
+
+        composeRule.onNodeWithTag(testTag = CART_RETRY).performClick()
+
+        assertTrue(retryClicked)
+    }
+
+    @Test
+    fun givenEmptySuccessState_whenRendered_thenShowsEmptyCartMessage() {
+        createCartScreen(
+            state = CartUiState.Success(
+                summary = null,
+                isLoading = false,
+                cartItems = emptyList()
+            )
+        )
+
+        composeRule.onNodeWithTag(testTag = CART_EMPTY).assertIsDisplayed()
+        composeRule.onNodeWithText("Tu carrito está vacío").assertIsDisplayed()
+        composeRule.onNodeWithText("Agrega productos para comenzar").assertIsDisplayed()
+    }
+
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/cart/presentation/CartScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/cart/presentation/CartScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
@@ -52,6 +53,9 @@ import com.amrubio27.cursotestingandroid.cart.domain.model.CartSummary
 import com.amrubio27.cursotestingandroid.cart.presentation.model.CartItemWithPromotion
 import com.amrubio27.cursotestingandroid.core.presentation.components.MarketTopAppBar
 import com.amrubio27.cursotestingandroid.core.presentation.components.QuantitySelector
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.CART_EMPTY
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.CART_LOADING
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.CART_RETRY
 import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductPromotion
 import java.text.NumberFormat
 import java.util.Currency.getInstance
@@ -72,6 +76,37 @@ fun CartScreen(
         }
     }
 
+    CartContent(
+        uiState = uiState,
+        snackbarHostState = snackbarHostState,
+        onBack = onBack,
+        onRetrySelected = { cartViewModel.refresh() },
+        onIncreaseQuantity = { productId, quantity ->
+            cartViewModel.increaseQuantity(
+                productId,
+                quantity
+            )
+        },
+        onDecreaseQuantity = { productId, quantity ->
+            cartViewModel.decreaseQuantity(
+                productId,
+                quantity
+            )
+        },
+        onRemove = { id -> cartViewModel.removeFromCart(id) }
+    )
+}
+
+@Composable
+fun CartContent(
+    uiState: CartUiState,
+    snackbarHostState: SnackbarHostState = SnackbarHostState(),
+    onBack: () -> Unit,
+    onRetrySelected: () -> Unit,
+    onIncreaseQuantity: (String, Int) -> Unit,
+    onDecreaseQuantity: (String, Int) -> Unit,
+    onRemove: (String) -> Unit
+) {
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
@@ -79,7 +114,7 @@ fun CartScreen(
                 title = "Carrito",
                 onBackSelected = { onBack() })
         }) { paddingValues ->
-        when (val state = uiState) {
+        when (uiState) {
             CartUiState.Loading -> {
                 CartLoadingStateScreen(
                     Modifier
@@ -93,8 +128,9 @@ fun CartScreen(
                     Modifier
                         .fillMaxSize()
                         .padding(paddingValues),
-                    state,
-                ) { cartViewModel.refresh() }
+                    uiState,
+                    onRetrySelected
+                )
             }
 
             is CartUiState.Success -> {
@@ -102,17 +138,15 @@ fun CartScreen(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(paddingValues),
-                    state = state,
-                    onIncreaseQuantity = { productId, quantity ->
-                        cartViewModel.increaseQuantity(productId, quantity)
-                    },
-                    onDecreaseQuantity = { productId, quantity ->
-                        cartViewModel.decreaseQuantity(productId, quantity)
-                    },
-                    onRemove = { id -> cartViewModel.removeFromCart(id) })
+                    state = uiState,
+                    onIncreaseQuantity = onIncreaseQuantity,
+                    onDecreaseQuantity = onDecreaseQuantity,
+                    onRemove = onRemove
+                )
             }
         }
     }
+
 }
 
 @Composable
@@ -130,7 +164,9 @@ fun CartErrorStateScreen(
             color = MaterialTheme.colorScheme.error
         )
         Spacer(Modifier.height(16.dp))
-        Button(onClick = { onRetrySelected() }) {
+        Button(
+            modifier = Modifier.testTag(CART_RETRY),
+            onClick = { onRetrySelected() }) {
             Text("Reintentar")
         }
     }
@@ -139,7 +175,7 @@ fun CartErrorStateScreen(
 @Composable
 fun CartLoadingStateScreen(modifier: Modifier = Modifier) {
     Box(modifier, contentAlignment = Alignment.Center) {
-        CircularProgressIndicator()
+        CircularProgressIndicator(modifier = Modifier.testTag(CART_LOADING))
     }
 }
 
@@ -162,7 +198,9 @@ fun CartSuccessStateScreen(
         AnimatedContent(state.cartItems.isEmpty()) { isEmpty ->
             if (isEmpty) {
                 Column(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .testTag(CART_EMPTY),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/testing/UiTestTag.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/testing/UiTestTag.kt
@@ -27,5 +27,16 @@ object UiTestTag {
     fun productListSortOption(sortOption: SortOption) =
         "product_list_sort_${sortOption.name.lowercase()}"
 
+    //CART SCREEN
+    const val CART_LOADING = "cart_loading"
+    const val CART_RETRY = "cart_retry"
+    const val CART_EMPTY = "cart_empty"
 
+    /*const val CART_LIST = "cart_list"
+
+    const val CART_ERROR = "cart_error"
+    fun cartItem(productId: String) = "cart_item_$productId"
+    fun cartItemIncrease(productId: String) = "cart_item_increase_$productId"
+    fun cartItemDecrease(productId: String) = "cart_item_decrease_$productId"
+    fun cartItemRemove(productId: String) = "cart_item_remove_$productId"*/
 }


### PR DESCRIPTION
# 🧪 feat(testing): tests de `CartScreen` y estandarización de `UiTestTag` para el carrito

## 📌 Resumen

Esta PR documenta y explica los cambios introducidos en:
- `app/src/main/java/.../core/presentation/testing/UiTestTag.kt` (nuevos tags para `Cart`),
- `app/src/main/java/.../cart/presentation/CartScreen.kt` (composición y estados del carrito),
- `app/src/androidTest/.../cart/presentation/CartScreenTest.kt` (tests UI instrumentados).

El objetivo del commit es asegurar que la UI del carrito:
- muestra el estado de loading,
- muestra errores y permite reintentar (callback),
- muestra el estado vacío con el contenido esperado,
- y que esos comportamientos sean testeables de manera estable mediante `testTag`s.

---

## 📁 Archivos implicados (cambios principales)

- `UiTestTag.kt` — Añadidos tags usados por los tests del carrito:
  - `CART_LOADING`
  - `CART_RETRY`
  - `CART_EMPTY`

- `CartScreen.kt` — Composables:
  - `CartScreen` (orquestador con ViewModel)
  - `CartContent` (Scaffold + ramas por `CartUiState`)
  - `CartLoadingStateScreen` (usa `CART_LOADING` testTag)
  - `CartErrorStateScreen` (muestra mensaje y botón `Reintentar` con `CART_RETRY`)
  - `CartSuccessStateScreen` (muestra `CartItemCard` o `CartEmpty` con `CART_EMPTY` tag cuando la lista está vacía)

- `CartScreenTest.kt` — Tests instrumentados que validan:
  - Loading visible
  - Error con texto y botón de reintento
  - Click en reintento ejecuta el callback
  - Empty state muestra mensajes y tag `CART_EMPTY`

---

## 🧪 Tests actuales y por qué tienen sentido

A continuación detallo cada test que existe en `CartScreenTest.kt`, qué valida y su correspondencia con la implementación.

### 1) `givenLoadingState_whenRendered_thenShowProgressView`

Código (test):
```kotlin
createCartScreen(state = CartUiState.Loading)
composeRule.onNodeWithTag(testTag = CART_LOADING).assertIsDisplayed()
```

Qué valida:
- Que, cuando `CartContent` recibe `CartUiState.Loading`, renderiza la vista de carga con un `CircularProgressIndicator` y que éste tiene el `testTag` `CART_LOADING`.

Por qué tiene sentido:
- `CartScreen` (a través de `CartContent`) tiene una rama específica para `CartUiState.Loading` — mostrar spinner es el comportamiento esperado durante refresco o carga. Probarlo asegura que la UX de espera aparece en el estado correcto.

Notas de implementación:
- En `CartLoadingStateScreen` se usa `Modifier.testTag(CART_LOADING)` en el `CircularProgressIndicator`, por eso el test lo localiza con seguridad.

---

### 2) `givenErrorState_whenRendered_thenShowTextAndRetryButton`

Código (test):
```kotlin
val errorText = "Prueba error"
createCartScreen(state = CartUiState.Error(errorText))
composeRule.onNodeWithText(errorText, substring = true, ignoreCase = true).assertIsDisplayed()
composeRule.onNodeWithText("Reintentar").assertIsDisplayed()
```

Qué valida:
- Que al renderizar `CartUiState.Error(...)`, el texto de error se muestra y el botón con texto `"Reintentar"` aparece.

Por qué tiene sentido:
- `CartErrorStateScreen` muestra un mensaje de error y un botón de retry. El test confirma la presencia del mensaje y del botón (UX & accesibilidad mínima).

Notas:
- El test usa `onNodeWithText(..., substring = true, ignoreCase = true)` para ser robusto al contenido exacto del mensaje (subcadena e insensitive), útil si el mensaje se compone con prefijo `"Error: ..."`.

---

### 3) `givenErrorState_whenRetryClicked_thenEmitsRetryCallback`

Código (test):
```kotlin
var retryClicked: Boolean = false
createCartScreen(state = CartUiState.Error(errorText), onRetrySelected = { retryClicked = true })
composeRule.onNodeWithTag(testTag = CART_RETRY).performClick()
assertTrue(retryClicked)
```

Qué valida:
- Que al pulsar el botón con `testTag = CART_RETRY` se ejecuta la lambda `onRetrySelected`.

Por qué tiene sentido:
- `CartContent` delega la acción de reintento hacia la lambda `onRetrySelected`. El test verifica el wiring UI → callback (no hace refresh real, solo comprueba que se llama la lambda).

Notas de implementación:
- `CartErrorStateScreen` marca el botón `Reintentar` con `Modifier.testTag(CART_RETRY)` para que el test lo localice sin depender del texto.

---

### 4) `givenEmptySuccessState_whenRendered_thenShowsEmptyCartMessage`

Código (test):
```kotlin
createCartScreen(state = CartUiState.Success(summary = null, isLoading = false, cartItems = emptyList()))
composeRule.onNodeWithTag(testTag = CART_EMPTY).assertIsDisplayed()
composeRule.onNodeWithText("Tu carrito está vacío").assertIsDisplayed()
composeRule.onNodeWithText("Agrega productos para comenzar").assertIsDisplayed()
```

Qué valida:
- Que una `CartUiState.Success` con `cartItems = emptyList()` renderiza la vista vacía del carrito (tag `CART_EMPTY`) y los textos previstos.

Por qué tiene sentido:
- Es la principal UX para un carrito sin items: informar al usuario y ofrecer CTA (en este caso, mostrar textos). Garantizarlo evita que una rama vacía no se muestre por accidente.

Notas:
- `CartSuccessStateScreen` usa `AnimatedContent` para alternar entre estado vacío y lista. El componente vacío incluye `Modifier.testTag(CART_EMPTY)` para localización fiable.

---

## 🔗 Relación implementación ↔ tests (por tags)

- `CART_LOADING` → aplicado en `CartLoadingStateScreen` al `CircularProgressIndicator`.
- `CART_RETRY` → aplicado al `Button` de reintento en `CartErrorStateScreen`.
- `CART_EMPTY` → aplicado al contenedor del estado vacío en `CartSuccessStateScreen`.

Uso de tags: evita buscar por texto o estructura, lo que hace tests más estables y menos sensibles a cambios visuales o de i18n.

---

## ⚠️ Riesgos y puntos a vigilar (flakiness y AnimatedContent)

1. AnimatedContent transiciones:
   - `CartSuccessStateScreen` usa `AnimatedContent(state.cartItems.isEmpty())`. Las transiciones pueden introducir flakiness si el test consulta inmediatamente sin esperar a que termine la animación.
   - Recomendación: en tests que interactúan con vistas que aparecen mediante animaciones, usar `composeRule.waitForIdle()` o avanzar el `mainClock` si se usa testing rule con control de reloj.
   - Alternativa: en tests unitarios/instrumentales preferir crear `uiState` ya establecido (como se hace en estos tests), que reduce necesidad de esperar transiciones.

2. Localización por texto:
   - El test de error usa `onNodeWithText(errorText, substring = true, ignoreCase = true)` para ser robusto.
   - Para el botón de retry el test usa `CART_RETRY` tag — este es el patrón recomendado.

3. SwipeToDismiss en `CartItemCard`:
   - Actualmente no testeado aquí. Si se añade test para `onRemove` mediante swipe, habrá que usar helpers específicos de swipe y tags en los items.

---

## ✅ Recomendaciones / próximos tests a añadir (prácticos y concretos)

Estos tests completan la cobertura funcional del carrito y siguen la misma filosofía:

1. Test de incremento/decremento de cantidad (unitario en UI):
   - Añadir `testTag`s en `QuantitySelector` dentro de `CartItemCard`:
     - ejemplo: `CART_ITEM_INCREASE_{productId}`, `CART_ITEM_DECREASE_{productId}`, `CART_ITEM_QUANTITY_{productId}`.
   - Test: renderizar `CartUiState.Success` con 1 item; pulsar increase/decrease y verificar que las callbacks `onIncreaseQuantity`/`onDecreaseQuantity` se llaman con los parámetros correctos.

2. Test de eliminación por swipe:
   - Añadir `testTag` al item que permita localizarlo y simular swipe-to-dismiss; validar que `onRemove` se invoca.
   - Nota: Compose testing soporta gestos; usar helper `performTouchInput { swipeLeft() }` sobre el nodo con tag.

3. Test del `CartSummaryCard`:
   - Renderizar success con `summary` y validar que `Subtotal`/`Total` se muestran con los valores correctos.

4. Tests de integración con ViewModel:
   - Usar un `FakeCartViewModel` o inyección Hilt test para validar flujo completo (refresh → loading → success).

---

## 🛠️ Mejores prácticas aplicadas

- Usar `testTag` para elementos interactivos (`CART_RETRY`, `CART_LOADING`, `CART_EMPTY`) — hace los tests robustos a i18n/cambio de copy.
- Separar tests de render y tests de interacción:
  - Render tests: validar que la UI refleja el estado (loading, error, empty).
  - Interaction tests: validar que la UI emite eventos con los parámetros esperados.
- Evitar aserciones frágiles por texto salvo cuando se testea contenido textual en sí (mensaje de error, mensajes vacíos).

---

## Ejemplo de test adicional sugerido (increase quantity)

```kotlin
@Test
fun givenCartWithItem_whenIncreaseClicked_thenCallsOnIncreaseQuantity() {
    var calledWith: Pair<String, Int>? = null
    val item = ... // crear CartUiState.Success con 1 item id = "p1", quantity = 1
    createCartScreen(
        state = CartUiState.Success(summary = ..., isLoading = false, cartItems = listOf(item)),
        onIncreaseQuantity = { id, q -> calledWith = id to q }
    )

    composeRule.onNodeWithTag(testTag = "cart_item_increase_p1").performClick()
    assertEquals("p1" to 1, calledWith)
}
```

Para esto hay que exponer los `testTag`s correspondientes desde `CartItemCard` (se sugiere añadirlos).

---

## Conclusión

Los tests presentes en `CartScreenTest.kt` cubren las rutas críticas de la experiencia del carrito: loading, error+retry y vacío.  
Los `testTag`s añadidos en `UiTestTag.kt` y aplicados en `CartScreen.kt` permiten localizar nodos de forma estable y validar las interacciones reales (callbacks). Esto hace que la suite sea una especificación ejecutable y resistente frente a refactors visuales.

---