### PR TITLE
Implement ui testing for Product Detail screen

### DIFF
--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailScreenTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailScreenTest.kt
@@ -1,0 +1,144 @@
+package com.amrubio27.cursotestingandroid.detail.presentation
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.amrubio27.cursotestingandroid.core.mothers.ProductMother.coffee
+import com.amrubio27.cursotestingandroid.core.mothers.PromotionMother.buyXPayY
+import com.amrubio27.cursotestingandroid.core.mothers.PromotionMother.percent
+import com.amrubio27.cursotestingandroid.core.mothers.uistate.ProductDetailUiStateMother
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.PRODUCT_DETAIL_ADD_TO_CART
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.PRODUCT_DETAIL_LOADING
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.TOP_APP_BAR
+import junit.framework.TestCase.assertTrue
+import org.junit.Rule
+import kotlin.test.Test
+
+class ProductDetailScreenTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun createProductDetailScreen(
+        uiState: ProductDetailUiState = ProductDetailUiStateMother.success(),
+        onBack: () -> Unit = {},
+        onAddToCart: () -> Unit = {}
+    ) {
+        composeRule.setContent {
+            ProductDetailContent(
+                uiState = uiState,
+                onBack = onBack,
+                onAddToCart = onAddToCart
+            )
+        }
+    }
+
+    @Test
+    fun givenLoadingState_whenRendered_thenShowsProgressView() {
+        createProductDetailScreen(uiState = ProductDetailUiStateMother.loading())
+
+        composeRule.onNodeWithTag(testTag = PRODUCT_DETAIL_LOADING).assertIsDisplayed()
+    }
+
+    @Test
+    fun givenSuccessStateNoPromotion_whenRendered_thenShowsProductDetailsAndAddToCartButtonEnabled() {
+        val product = coffee(stock = 5)
+        createProductDetailScreen(
+            uiState = ProductDetailUiStateMother.success(
+                product = product,
+                promotion = null
+            )
+        )
+
+        composeRule.onAllNodesWithText(product.name).onFirst().assertIsDisplayed()
+        composeRule.onNodeWithText(product.category).assertIsDisplayed()
+        composeRule.onNodeWithText(product.description).assertIsDisplayed()
+        composeRule.onNodeWithText(product.price.toString()).assertIsDisplayed()
+        composeRule.onNodeWithText("5 unidades").assertIsDisplayed()
+
+        composeRule.onNodeWithTag(testTag = PRODUCT_DETAIL_ADD_TO_CART).assertIsEnabled()
+    }
+
+    @Test
+    fun givenSuccessStatePercentPromotion_whenRendered_thenShowsProductDiscountAndDiscountedPrice() {
+        val product = coffee()
+        val promo = percent(percent = 20.0, discountedPrice = 3.60)
+        createProductDetailScreen(
+            uiState = ProductDetailUiStateMother.success(
+                product = product,
+                promotion = promo
+            )
+        )
+
+        // Precio original
+        composeRule.onNodeWithText(product.price.toString()).assertIsDisplayed()
+        // Descuento
+        composeRule.onNodeWithText("3.6").assertIsDisplayed()
+        // Porcentaje
+        composeRule.onNodeWithText("20% OFF ").assertIsDisplayed()
+    }
+
+    @Test
+    fun givenSuccessStateBuyXPayYPromotion_whenRendered_thenShowsBuyXPayYPromotionLabel() {
+        val product = coffee()
+        val promo = buyXPayY(buy = 3, pay = 2, label = "3x2")
+        createProductDetailScreen(
+            uiState = ProductDetailUiStateMother.success(
+                product = product,
+                promotion = promo
+            )
+        )
+
+        // Precio original
+        composeRule.onNodeWithText(product.price.toString()).assertIsDisplayed()
+        // Etiqueta de promoción 3x2
+        composeRule.onNodeWithText("PROMO: 3x2").assertIsDisplayed()
+    }
+
+    @Test
+    fun givenSuccessStateNoStock_whenRendered_thenShowsNoStockAndAddToCartButtonDisabled() {
+        val product = coffee(stock = 0)
+        createProductDetailScreen(
+            uiState = ProductDetailUiStateMother.success(
+                product = product,
+                promotion = null
+            )
+        )
+
+        composeRule.onNodeWithText("Sin stock").assertIsDisplayed()
+        composeRule.onNodeWithTag(testTag = PRODUCT_DETAIL_ADD_TO_CART).assertIsNotEnabled()
+    }
+
+    @Test
+    fun givenProductDetailRendered_whenBackClicked_thenEmitBackCallback() {
+        var backClicked = false
+        createProductDetailScreen(
+            uiState = ProductDetailUiStateMother.success(),
+            onBack = { backClicked = true }
+        )
+
+        composeRule.onNodeWithTag(testTag = TOP_APP_BAR).performClick()
+
+        assertTrue(backClicked)
+    }
+
+    @Test
+    fun givenProductDetailRendered_whenAddToCartClicked_thenEmitAddToCartCallback() {
+        var addToCartClicked = false
+        createProductDetailScreen(
+            uiState = ProductDetailUiStateMother.success(),
+            onAddToCart = { addToCartClicked = true }
+        )
+
+        composeRule.onNodeWithTag(testTag = PRODUCT_DETAIL_ADD_TO_CART).performClick()
+
+        assertTrue(addToCartClicked)
+    }
+}

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/testing/UiTestTag.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/testing/UiTestTag.kt
@@ -35,4 +35,8 @@ object UiTestTag {
     fun cartItem(productId: String) = "cart_item_$productId"
     fun cartQuantityIncrease(productId: String) = "cart_quantity_increase_$productId"
     fun cartQuantityDecrease(productId: String) = "cart_quantity_decrease_$productId"
+
+    // PRODUCT DETAIL
+    const val PRODUCT_DETAIL_LOADING = "product_detail_loading"
+    const val PRODUCT_DETAIL_ADD_TO_CART = "product_detail_add_to_cart"
 }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
@@ -38,6 +39,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.amrubio27.cursotestingandroid.R
 import com.amrubio27.cursotestingandroid.core.presentation.components.MarketTopAppBar
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.PRODUCT_DETAIL_LOADING
 import com.amrubio27.cursotestingandroid.detail.presentation.components.AddToCartButton
 import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductPromotion
 
@@ -77,6 +79,21 @@ fun ProductDetailScreen(
         }
     }
 
+    ProductDetailContent(
+        uiState = uiState,
+        snackbarHostState = snackbarHostState,
+        onBack = onBack,
+        onAddToCart = { productDetailViewModel.addToCart() }
+    )
+}
+
+@Composable
+fun ProductDetailContent(
+    uiState: ProductDetailUiState,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+    onBack: () -> Unit,
+    onAddToCart: () -> Unit
+) {
     Scaffold(topBar = {
         MarketTopAppBar(
             title = uiState.item?.product?.name.orEmpty(), onBackSelected = { onBack() })
@@ -87,10 +104,9 @@ fun ProductDetailScreen(
             AddToCartButton(
                 modifier = Modifier.weight(1f),
                 product = uiState.item?.product,
-                isLoading = uiState.isLoading
-            ) {
-                productDetailViewModel.addToCart()
-            }
+                isLoading = uiState.isLoading,
+                addToCart = onAddToCart
+            )
         }
     }, snackbarHost = { SnackbarHost(snackbarHostState) }) { paddingValues ->
         Column(
@@ -101,7 +117,7 @@ fun ProductDetailScreen(
         ) {
             if (uiState.isLoading) {
                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    CircularProgressIndicator()
+                    CircularProgressIndicator(modifier = Modifier.testTag(PRODUCT_DETAIL_LOADING))
                 }
             } else {
                 uiState.item?.let {
@@ -275,4 +291,3 @@ fun ProductDetailScreen(
         }
     }
 }
-

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/components/AddToCartButtonNoStock.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/components/AddToCartButtonNoStock.kt
@@ -17,8 +17,10 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.PRODUCT_DETAIL_ADD_TO_CART
 
 @Composable
 fun AddToCartButtonNoStock(modifier: Modifier = Modifier) {
@@ -27,7 +29,9 @@ fun AddToCartButtonNoStock(modifier: Modifier = Modifier) {
     ) {
         Box(Modifier.padding(16.dp)) {
             Button(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(PRODUCT_DETAIL_ADD_TO_CART),
                 onClick = {},
                 enabled = false,
                 shape = RoundedCornerShape(12.dp),

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/components/AddToCartButtonWithStock.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/components/AddToCartButtonWithStock.kt
@@ -17,8 +17,10 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.PRODUCT_DETAIL_ADD_TO_CART
 import com.amrubio27.cursotestingandroid.productlist.domain.model.Product
 
 @Composable
@@ -33,7 +35,9 @@ fun AddToCartButtonWithStock(
     ) {
         Box(Modifier.padding(16.dp)) {
             Button(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(PRODUCT_DETAIL_ADD_TO_CART),
                 onClick = { addToCart() },
                 enabled = !isLoading,
                 shape = RoundedCornerShape(12.dp),

--- a/app/src/sharedTest/java/com/amrubio27/cursotestingandroid/core/mothers/PromotionMother.kt
+++ b/app/src/sharedTest/java/com/amrubio27/cursotestingandroid/core/mothers/PromotionMother.kt
@@ -6,4 +6,8 @@ object PromotionMother {
     fun percent(
         percent: Double = 25.0, discountedPrice: Double = 4.65
     ) = ProductPromotion.Percent(percent = percent, discountedPrice = discountedPrice)
+
+    fun buyXPayY(
+        buy: Int = 2, pay: Int = 1, label: String = "2x1"
+    ) = ProductPromotion.BuyXPayY(buy = buy, pay = pay, label = label)
 }

--- a/app/src/sharedTest/java/com/amrubio27/cursotestingandroid/core/mothers/uistate/ProductDetailUiStateMother.kt
+++ b/app/src/sharedTest/java/com/amrubio27/cursotestingandroid/core/mothers/uistate/ProductDetailUiStateMother.kt
@@ -1,0 +1,24 @@
+package com.amrubio27.cursotestingandroid.core.mothers.uistate
+
+import com.amrubio27.cursotestingandroid.core.mothers.ProductMother
+import com.amrubio27.cursotestingandroid.detail.presentation.ProductDetailUiState
+import com.amrubio27.cursotestingandroid.productlist.domain.model.Product
+import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductPromotion
+import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductWithPromotion
+
+object ProductDetailUiStateMother {
+
+    fun success(
+        product: Product = ProductMother.coffee(),
+        promotion: ProductPromotion? = null,
+        isLoading: Boolean = false
+    ) = ProductDetailUiState(
+        item = ProductWithPromotion(product, promotion),
+        isLoading = isLoading
+    )
+
+    fun loading() = ProductDetailUiState(
+        item = null,
+        isLoading = true
+    )
+}


### PR DESCRIPTION
# Explicación de la Refactorización y Pruebas de UI (`ProductDetailScreen`)

Este documento sirve como guía didáctica y apuntes de referencia para entender los cambios realizados para probar la UI de la pantalla `ProductDetailScreen` utilizando **Jetpack Compose Testing**, **State Hoisting**, y el patrón **Object Mother**.

---

## 1. Arquitectura de las Pantallas: Stateful vs. Stateless

En Jetpack Compose, para realizar pruebas de interfaz de usuario de forma aislada y predecible, es fundamental aplicar el patrón de **State Hoisting** (elevación de estado). 

### Problema Inicial
Anteriormente, `ProductDetailScreen` realizaba la inyección directa de `ProductDetailViewModel` a nivel de componente y gestionaba efectos secundarios (`LaunchedEffect`) dentro del mismo bloque de código que dibujaba la interfaz. Esto hacía imposible probar la UI sin simular o mockear el ViewModel, el inyector de dependencias (Hilt) y los flujos de corrutinas en segundo plano.

### Solución: División en Screen y Content
Hemos dividido la pantalla en dos funciones Composable:

1. **`ProductDetailScreen` (Stateful)**: Se encarga de la integración con la arquitectura de Android.
   - Obtiene el ViewModel inyectado por Hilt.
   - Escucha los estados y eventos a través de corrutinas (`collectAsStateWithLifecycle` y `LaunchedEffect`).
   - Delega toda la renderización a la función stateless.
2. **`ProductDetailContent` (Stateless)**: Es una función pura de Compose.
   - **Entradas**: Recibe el estado (`ProductDetailUiState`), el `SnackbarHostState` y callbacks para las interacciones (`onBack`, `onAddToCart`).
   - No tiene dependencias de ViewModels ni lógicas de negocio, lo que la hace **100% testeable en aislamiento** con `composeTestRule.setContent`.

#### Ejemplo de Código Refactorizado:
```kotlin
// Pantalla con Estado (Stateful) - Utilizada por la navegación real
@Composable
fun ProductDetailScreen(
    productId: String,
    onBack: () -> Unit,
    productDetailViewModel: ProductDetailViewModel = hiltViewModel()
) {
    val uiState by productDetailViewModel.uiState.collectAsStateWithLifecycle()
    val snackbarHostState = remember { SnackbarHostState() }

    LaunchedEffect(productId) { productDetailViewModel.loadProduct(productId) }
    
    // Escucha de eventos para mostrar Snackbars
    LaunchedEffect(Unit) {
        productDetailViewModel.events.collect { event ->
            // Manejo de snackbars...
        }
    }

    ProductDetailContent(
        uiState = uiState,
        snackbarHostState = snackbarHostState,
        onBack = onBack,
        onAddToCart = { productDetailViewModel.addToCart() }
    )
}

// Contenido sin Estado (Stateless) - Utilizada para renderizar y en los Test de UI
@Composable
fun ProductDetailContent(
    uiState: ProductDetailUiState,
    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
    onBack: () -> Unit,
    onAddToCart: () -> Unit
) {
    Scaffold(
        topBar = { MarketTopAppBar(title = uiState.item?.product?.name.orEmpty(), onBackSelected = onBack) },
        bottomBar = { /* Botón Agregar al carrito */ }
    ) { paddingValues ->
        // Renderizado del producto basándose únicamente en uiState
    }
}
```

---

## 2. Sistema de Test Tags (`UiTestTag`)

Para localizar de forma única los componentes de UI en las pruebas sin depender de textos traducibles o cambiantes, utilizamos el objeto [UiTestTag](file:///d:/Programacion/cursoTestingAndroid/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/testing/UiTestTag.kt).

Añadimos dos nuevas constantes:
- `PRODUCT_DETAIL_LOADING`: Tag para el `CircularProgressIndicator` que se muestra cuando `isLoading == true`.
- `PRODUCT_DETAIL_ADD_TO_CART`: Tag único para el botón de añadir al carrito.

### Buenas Prácticas: Reutilización de Tags para Estados Opuestos
En lugar de crear tags diferentes para el botón con stock (`AddToCartButtonWithStock`) y sin stock (`AddToCartButtonNoStock`), hemos asignado el mismo tag `PRODUCT_DETAIL_ADD_TO_CART` al botón físico dentro de ambos componentes.
Esto nos permite escribir aserciones elegantes en los tests:
```kotlin
// Si hay stock, verificamos que el botón existe y está habilitado
composeRule.onNodeWithTag(PRODUCT_DETAIL_ADD_TO_CART).assertIsEnabled()

// Si no hay stock, verificamos que el mismo botón está deshabilitado
composeRule.onNodeWithTag(PRODUCT_DETAIL_ADD_TO_CART).assertIsNotEnabled()
```

---

## 3. Patrón Object Mother para UI States

El patrón **Object Mother** (u objeto madre) centraliza la creación de datos de prueba para evitar duplicación y hacer que los tests sean legibles. 

Creamos [ProductDetailUiStateMother](file:///d:/Programacion/cursoTestingAndroid/app/src/sharedTest/java/com/amrubio27/cursotestingandroid/core/mothers/uistate/ProductDetailUiStateMother.kt) en la carpeta `sharedTest` (compartida por tests unitarios e instrumentados):
```kotlin
object ProductDetailUiStateMother {
    // Genera un estado con datos listos para renderizar
    fun success(
        product: Product = ProductMother.coffee(),
        promotion: ProductPromotion? = null,
        isLoading: Boolean = false
    ) = ProductDetailUiState(
        item = ProductWithPromotion(product, promotion),
        isLoading = isLoading
    )

    // Genera el estado de carga
    fun loading() = ProductDetailUiState(
        item = null,
        isLoading = true
    )
}
```
También añadimos un helper para promociones del tipo "Compra X y Paga Y" en [PromotionMother](file:///d:/Programacion/cursoTestingAndroid/app/src/sharedTest/java/com/amrubio27/cursotestingandroid/core/mothers/PromotionMother.kt):
```kotlin
fun buyXPayY(
    buy: Int = 2, pay: Int = 1, label: String = "2x1"
) = ProductPromotion.BuyXPayY(buy = buy, pay = pay, label = label)
```

---

## 4. Explicación de los Casos de Prueba Implementados

La clase [ProductDetailScreenTest](file:///d:/Programacion/cursoTestingAndroid/app/src/androidTest/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailScreenTest.kt) verifica todos los estados posibles del flujo visual:

### 1. Estado de Carga
* **Test**: `givenLoadingState_whenRendered_thenShowsProgressView`
* **Explicación**: Comprueba que si `isLoading` es `true`, se muestra el indicador circular en pantalla mediante su `testTag`.

### 2. Producto Sin Promoción y Con Stock
* **Test**: `givenSuccessStateNoPromotion_whenRendered_thenShowsProductDetailsAndAddToCartButtonEnabled`
* **Explicación**: Verifica que se pinta correctamente toda la información del producto (nombre, descripción, categoría, precio normal y número de unidades). Valida que el botón de añadir al carrito esté activo.

### 3. Producto con Descuento Porcentual
* **Test**: `givenSuccessStatePercentPromotion_whenRendered_thenShowsProductDiscountAndDiscountedPrice`
* **Explicación**: Cuando un producto tiene una promoción de tipo `Percent`, el sistema debe tachar el precio original, mostrar el nuevo precio rebajado y un indicador visual de descuento (ej. "20% OFF").

### 4. Producto con Promoción "Compra X y Paga Y"
* **Test**: `givenSuccessStateBuyXPayYPromotion_whenRendered_thenShowsBuyXPayYPromotionLabel`
* **Explicación**: Verifica que para promociones de tipo `BuyXPayY` (como un 3x2), se muestre la etiqueta promocional correspondiente en color destacado (ej. "PROMO: 3x2").

### 5. Producto Sin Stock disponible
* **Test**: `givenSuccessStateNoStock_whenRendered_thenShowsNoStockAndAddToCartButtonDisabled`
* **Explicación**: Si el stock del producto es `0`, debe cambiar la etiqueta visual a "Sin stock" y deshabilitar el botón de compra (`assertIsNotEnabled`).

### 6. Emisión de Callback al pulsar atrás
* **Test**: `givenProductDetailRendered_whenBackClicked_thenEmitBackCallback`
* **Explicación**: Simula el click en la flecha de volver atrás del `TopAppBar` y verifica que se dispare el evento correspondiente.

### 7. Emisión de Callback al añadir al carrito
* **Test**: `givenProductDetailRendered_whenAddToCartClicked_thenEmitAddToCartCallback`
* **Explicación**: Simula la pulsación del botón activo de añadir al carrito y confirma que se invoque la acción delegada en el ViewModel.

---

## 5. Lección Aprendida: Manejo de Nodos Duplicados en Compose

Durante la ejecución inicial, nos encontramos con el siguiente error:
> `java.lang.AssertionError: Failed to perform checkIsDisplayed check: Expected at most 1 node but found 2 nodes that satisfy...`

### ¿Por qué ocurrió?
Al buscar el nodo con el nombre del producto usando `onNodeWithText(product.name)`, Compose encontró **dos** elementos que cumplían la condición:
1. El título en la barra superior (`MarketTopAppBar(title = product.name)`).
2. El título principal en la tarjeta central de descripción del producto.

### Solución
Cuando existen múltiples componentes válidos y no se ha especificado un tag diferenciador para cada texto secundario, se debe utilizar `onAllNodesWithText` en combinación con `.onFirst()` (o `.onLast()`, o indexación `[0]`):
```kotlin
// CORRECTO: Selecciona explícitamente el primer nodo que coincida con el texto
composeRule.onAllNodesWithText(product.name).onFirst().assertIsDisplayed()
```
Esto resuelve la ambigüedad en el árbol de semántica de Jetpack Compose y permite que los tests pasen exitosamente.
