### PR TITLE
Externalize hardcoded strings to `strings.xml`

### DIFF
--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/cart/presentation/CartScreenTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/cart/presentation/CartScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeRight
+import com.amrubio27.cursotestingandroid.R
 import com.amrubio27.cursotestingandroid.cart.presentation.model.CartItemWithPromotion
 import com.amrubio27.cursotestingandroid.core.mothers.CartUiStateMother.cartItemWithPromotion
 import com.amrubio27.cursotestingandroid.core.mothers.CartUiStateMother.cartSuccess
@@ -51,6 +52,10 @@ class CartScreenTest {
         }
     }
 
+    private fun getString(resId: Int): String = composeRule.activity.getString(resId)
+    private fun getString(resId: Int, vararg formatArgs: Any): String =
+        composeRule.activity.getString(resId, *formatArgs)
+
     @Test
     fun givenLoadingState_whenRendered_thenShowProgressView() {
         createCartScreen(state = CartUiState.Loading)
@@ -65,7 +70,7 @@ class CartScreenTest {
 
         composeRule.onNodeWithText(errorText, substring = true, ignoreCase = true)
             .assertIsDisplayed()
-        composeRule.onNodeWithText("Reintentar").assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.cart_retry_button)).assertIsDisplayed()
     }
 
     @Test
@@ -94,8 +99,8 @@ class CartScreenTest {
         )
 
         composeRule.onNodeWithTag(testTag = CART_EMPTY).assertIsDisplayed()
-        composeRule.onNodeWithText("Tu carrito está vacío").assertIsDisplayed()
-        composeRule.onNodeWithText("Agrega productos para comenzar").assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.cart_empty_title)).assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.cart_empty_subtitle)).assertIsDisplayed()
     }
 
     @Test
@@ -104,9 +109,9 @@ class CartScreenTest {
 
         composeRule.onNodeWithText(coffee().name).assertIsDisplayed()
         composeRule.onNodeWithText(bread().name).assertIsDisplayed()
-        composeRule.onNodeWithText("Subtotal:").assertIsDisplayed()
-        composeRule.onNodeWithText("Descuento:").assertIsDisplayed()
-        composeRule.onNodeWithText("Total:").assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.cart_subtotal_label)).assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.cart_discount_label)).assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.cart_total_label)).assertIsDisplayed()
 
         composeRule.onNodeWithTag(testTag = cartItem(productId = coffee().id)).assertIsDisplayed()
         composeRule.onNodeWithTag(testTag = cartItem(productId = bread().id)).assertIsDisplayed()

--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailScreenTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.amrubio27.cursotestingandroid.R
 import com.amrubio27.cursotestingandroid.core.mothers.ProductMother.coffee
 import com.amrubio27.cursotestingandroid.core.mothers.PromotionMother.buyXPayY
 import com.amrubio27.cursotestingandroid.core.mothers.PromotionMother.percent
@@ -40,6 +41,10 @@ class ProductDetailScreenTest {
         }
     }
 
+    private fun getString(resId: Int): String = composeRule.activity.getString(resId)
+    private fun getString(resId: Int, vararg formatArgs: Any): String =
+        composeRule.activity.getString(resId, *formatArgs)
+
     @Test
     fun givenLoadingState_whenRendered_thenShowsProgressView() {
         createProductDetailScreen(uiState = ProductDetailUiStateMother.loading())
@@ -61,7 +66,7 @@ class ProductDetailScreenTest {
         composeRule.onNodeWithText(product.category).assertIsDisplayed()
         composeRule.onNodeWithText(product.description).assertIsDisplayed()
         composeRule.onNodeWithText(product.price.toString()).assertIsDisplayed()
-        composeRule.onNodeWithText("5 unidades").assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.detail_stock_units, 5)).assertIsDisplayed()
 
         composeRule.onNodeWithTag(testTag = PRODUCT_DETAIL_ADD_TO_CART).assertIsEnabled()
     }
@@ -82,7 +87,7 @@ class ProductDetailScreenTest {
         // Descuento
         composeRule.onNodeWithText("3.6").assertIsDisplayed()
         // Porcentaje
-        composeRule.onNodeWithText("20% OFF ").assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.detail_percent_off, 20)).assertIsDisplayed()
     }
 
     @Test
@@ -99,7 +104,7 @@ class ProductDetailScreenTest {
         // Precio original
         composeRule.onNodeWithText(product.price.toString()).assertIsDisplayed()
         // Etiqueta de promoción 3x2
-        composeRule.onNodeWithText("PROMO: 3x2").assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.detail_promo, "3x2")).assertIsDisplayed()
     }
 
     @Test
@@ -112,7 +117,7 @@ class ProductDetailScreenTest {
             )
         )
 
-        composeRule.onNodeWithText("Sin stock").assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.detail_no_stock)).assertIsDisplayed()
         composeRule.onNodeWithTag(testTag = PRODUCT_DETAIL_ADD_TO_CART).assertIsNotEnabled()
     }
 

--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreenTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreenTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.amrubio27.cursotestingandroid.R
 import com.amrubio27.cursotestingandroid.core.mothers.ProductMother.bread
 import com.amrubio27.cursotestingandroid.core.mothers.ProductMother.coffee
 import com.amrubio27.cursotestingandroid.core.mothers.ProductMother.milk
@@ -57,6 +58,10 @@ class ProductListScreenTest {
         }
     }
 
+    private fun getString(resId: Int): String = composeRule.activity.getString(resId)
+    private fun getString(resId: Int, vararg formatArgs: Any): String =
+        composeRule.activity.getString(resId, *formatArgs)
+
     @Test
     fun givenLoadingState_whenRendered_thenShowsProgressView() {
         createProductListScreen(uiState = ProductListUiState.Loading)
@@ -68,14 +73,14 @@ class ProductListScreenTest {
     fun givenErrorState_whenRendered_thenShowsErrorMessage() {
         createProductListScreen(uiState = ProductListUiState.Error(""))
 
-        composeRule.onNodeWithText("ERROR").assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.error_title)).assertIsDisplayed()
     }
 
     @Test
     fun givenSuccessState_whenRendered_thenShowsProductsAndCount() {
         createProductListScreen(uiState = ProductListUiStateMother.success())
 
-        composeRule.onNodeWithText("3 productos").assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.product_list_count, 3)).assertIsDisplayed()
         composeRule.onNodeWithTag(testTag = FILTER_VIEW).assertIsDisplayed()
 
         composeRule.onNodeWithTag(testTag = productListItem(productId = coffee().id))
@@ -96,7 +101,7 @@ class ProductListScreenTest {
     fun givenSuccessState_whenRendered_thenShowsEmptyMessage() {
         createProductListScreen(uiState = ProductListUiStateMother.success(products = emptyList()))
 
-        composeRule.onNodeWithText("No se encontraron productos").assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.product_list_no_products)).assertIsDisplayed()
     }
 
     @Test

--- a/app/src/androidTest/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreenTest.kt
@@ -47,7 +47,7 @@ class SettingsScreenTest {
     @Test
     fun firstUITest() {
         createSettingsScreen()
-        composeRule.onNodeWithText("Ajustes").assertIsDisplayed()
+        composeRule.onNodeWithText(getString(R.string.settings_title)).assertIsDisplayed()
     }
 
     private fun getString(resId: Int): String = composeRule.activity.getString(resId)

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/cart/presentation/CartScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/cart/presentation/CartScreen.kt
@@ -43,12 +43,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import com.amrubio27.cursotestingandroid.R
 import com.amrubio27.cursotestingandroid.cart.domain.model.CartSummary
 import com.amrubio27.cursotestingandroid.cart.presentation.model.CartItemWithPromotion
 import com.amrubio27.cursotestingandroid.core.presentation.components.MarketTopAppBar
@@ -114,7 +116,7 @@ fun CartContent(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             MarketTopAppBar(
-                title = "Carrito",
+                title = stringResource(R.string.cart_title),
                 onBackSelected = { onBack() })
         }) { paddingValues ->
         when (uiState) {
@@ -162,7 +164,7 @@ fun CartErrorStateScreen(
         verticalArrangement = Arrangement.Center
     ) {
         Text(
-            "Error: ${state.message}",
+            stringResource(R.string.cart_error_message, state.message),
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.error
         )
@@ -170,7 +172,7 @@ fun CartErrorStateScreen(
         Button(
             modifier = Modifier.testTag(CART_RETRY),
             onClick = { onRetrySelected() }) {
-            Text("Reintentar")
+            Text(stringResource(R.string.cart_retry_button))
         }
     }
 }
@@ -212,13 +214,13 @@ fun CartSuccessStateScreen(
                         "🛒", style = MaterialTheme.typography.displayLarge
                     )
                     Text(
-                        "Tu carrito está vacío",
+                        stringResource(R.string.cart_empty_title),
                         style = MaterialTheme.typography.titleLarge,
                         color = MaterialTheme.colorScheme.secondary,
                         fontWeight = FontWeight.Bold
                     )
                     Text(
-                        "Agrega productos para comenzar",
+                        stringResource(R.string.cart_empty_subtitle),
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurface,
                     )
@@ -277,7 +279,7 @@ fun CartSummaryCard(modifier: Modifier, summary: CartSummary, currencyFormatter:
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             Text(
-                "Resumen del carrito",
+                stringResource(R.string.cart_summary_title),
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onPrimaryContainer,
                 fontWeight = FontWeight.Bold
@@ -288,7 +290,7 @@ fun CartSummaryCard(modifier: Modifier, summary: CartSummary, currencyFormatter:
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 Text(
-                    "Subtotal:",
+                    stringResource(R.string.cart_subtotal_label),
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onPrimaryContainer,
                 )
@@ -304,7 +306,7 @@ fun CartSummaryCard(modifier: Modifier, summary: CartSummary, currencyFormatter:
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     Text(
-                        "Descuento:",
+                        stringResource(R.string.cart_discount_label),
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.error,
                     )
@@ -326,7 +328,7 @@ fun CartSummaryCard(modifier: Modifier, summary: CartSummary, currencyFormatter:
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 Text(
-                    "Total:",
+                    stringResource(R.string.cart_total_label),
                     style = MaterialTheme.typography.titleLarge,
                     color = MaterialTheme.colorScheme.onPrimaryContainer,
                     fontWeight = FontWeight.Bold
@@ -438,14 +440,20 @@ fun CartItemCard(
                             )
 
                             Text(
-                                text = "${currencyFormatter.format(unitPrice)} c/u",
+                                text = stringResource(
+                                    R.string.cart_price_per_unit,
+                                    currencyFormatter.format(unitPrice)
+                                ),
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.primary,
                                 fontWeight = FontWeight.Bold
                             )
                         } else {
                             Text(
-                                text = "${currencyFormatter.format(unitPrice)} c/u",
+                                text = stringResource(
+                                    R.string.cart_price_per_unit,
+                                    currencyFormatter.format(unitPrice)
+                                ),
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -454,7 +462,10 @@ fun CartItemCard(
 
 
                     Text(
-                        "Total: ${currencyFormatter.format(itemTotal)}",
+                        stringResource(
+                            R.string.cart_item_total,
+                            currencyFormatter.format(itemTotal)
+                        ),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.primary
                     )

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/components/MarketTopAppBar.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/core/presentation/components/MarketTopAppBar.kt
@@ -12,7 +12,9 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import com.amrubio27.cursotestingandroid.R
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.TOP_APP_BAR
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -40,7 +42,7 @@ fun MarketTopAppBar(
             ) {
                 Icon(
                     Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "Back",
+                    contentDescription = stringResource(R.string.back_button_content_desc),
                     tint = MaterialTheme.colorScheme.onSurface
                 )
             }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
@@ -50,6 +51,11 @@ fun ProductDetailScreen(
     productDetailViewModel: ProductDetailViewModel = hiltViewModel()
 ) {
 
+    val insufficientStockMessage = stringResource(R.string.detail_error_insufficient_stock)
+    val networkErrorMessage = stringResource(R.string.detail_error_network)
+    val unknownErrorMessage = stringResource(R.string.detail_error_unknown)
+    val successAddedMessage = stringResource(R.string.detail_success_added)
+
     val uiState by productDetailViewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -61,19 +67,19 @@ fun ProductDetailScreen(
         productDetailViewModel.events.collect { event ->
             when (event) {
                 ProductDetailEvent.INSUFFICIENT_STOCK_ERROR -> {
-                    snackbarHostState.showSnackbar("No hay suficiente stock")
+                    snackbarHostState.showSnackbar(insufficientStockMessage)
                 }
 
                 ProductDetailEvent.NETWORK_ERROR -> {
-                    snackbarHostState.showSnackbar("No hay internet, compruebe su conexión")
+                    snackbarHostState.showSnackbar(networkErrorMessage)
                 }
 
                 ProductDetailEvent.UNKNOWN_ERROR -> {
-                    snackbarHostState.showSnackbar("Error inesperado, vuelva a intentarlo")
+                    snackbarHostState.showSnackbar(unknownErrorMessage)
                 }
 
                 ProductDetailEvent.SUCCESS_ADD_TO_CART -> {
-                    snackbarHostState.showSnackbar("Producto añadido")
+                    snackbarHostState.showSnackbar(successAddedMessage)
                 }
             }
         }
@@ -208,7 +214,10 @@ fun ProductDetailContent(
                                         color = MaterialTheme.colorScheme.errorContainer
                                     ) {
                                         Text(
-                                            "${(promotion as ProductPromotion.Percent).percent.toInt()}% OFF ",
+                                            stringResource(
+                                                R.string.detail_percent_off,
+                                                (promotion as ProductPromotion.Percent).percent.toInt()
+                                            ),
                                             modifier = Modifier.padding(
                                                 horizontal = 12.dp, vertical = 6.dp
                                             ),
@@ -232,7 +241,7 @@ fun ProductDetailContent(
                                         color = MaterialTheme.colorScheme.errorContainer
                                     ) {
                                         Text(
-                                            "PROMO: ${promotion.label}",
+                                            stringResource(R.string.detail_promo, promotion.label),
                                             modifier = Modifier.padding(
                                                 horizontal = 12.dp, vertical = 6.dp
                                             ),
@@ -263,7 +272,7 @@ fun ProductDetailContent(
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
                                     Text(
-                                        "Stock disponible",
+                                        stringResource(R.string.detail_stock_available),
                                         style = MaterialTheme.typography.bodyLarge,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant
                                     )
@@ -273,7 +282,10 @@ fun ProductDetailContent(
                                         color = stockContainerColor
                                     ) {
                                         Text(
-                                            text = if (hasStock) "${product.stock} unidades" else "Sin stock",
+                                            text = if (hasStock) stringResource(
+                                                R.string.detail_stock_units,
+                                                product.stock
+                                            ) else stringResource(R.string.detail_no_stock),
                                             modifier = Modifier.padding(
                                                 horizontal = 12.dp, vertical = 6.dp
                                             ),

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/components/AddToCartButtonNoStock.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/components/AddToCartButtonNoStock.kt
@@ -18,8 +18,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.amrubio27.cursotestingandroid.R
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.PRODUCT_DETAIL_ADD_TO_CART
 
 @Composable
@@ -44,7 +46,7 @@ fun AddToCartButtonNoStock(modifier: Modifier = Modifier) {
                 )
                 Spacer(Modifier.width(8.dp))
                 Text(
-                    "Sin stock disponible", fontWeight = FontWeight.Bold
+                    stringResource(R.string.detail_no_stock_available), fontWeight = FontWeight.Bold
                 )
             }
         }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/components/AddToCartButtonWithStock.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/components/AddToCartButtonWithStock.kt
@@ -18,8 +18,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.amrubio27.cursotestingandroid.R
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.PRODUCT_DETAIL_ADD_TO_CART
 import com.amrubio27.cursotestingandroid.productlist.domain.model.Product
 
@@ -50,7 +52,7 @@ fun AddToCartButtonWithStock(
                 )
                 Spacer(Modifier.width(8.dp))
                 Text(
-                    "Agregar al carrito", fontWeight = FontWeight.Bold
+                    stringResource(R.string.detail_add_to_cart), fontWeight = FontWeight.Bold
                 )
             }
         }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreen.kt
@@ -26,10 +26,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.amrubio27.cursotestingandroid.R
 import com.amrubio27.cursotestingandroid.cart.presentation.CartUiState
 import com.amrubio27.cursotestingandroid.cart.presentation.CartViewModel
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.PRODUCT_LIST_LIST
@@ -136,7 +138,7 @@ fun ProductListContent(
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
-                        "ERROR",
+                        stringResource(R.string.error_title),
                         fontSize = 30.sp,
                         color = Color.Red
                     )
@@ -163,7 +165,7 @@ fun ProductListContent(
                     }
 
                     Text(
-                        "${uiState.products.size} productos",
+                        stringResource(R.string.product_list_count, uiState.products.size),
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.secondary
@@ -181,7 +183,7 @@ fun ProductListContent(
                             ) {
                                 Text("🔍", style = MaterialTheme.typography.displayMedium)
                                 Text(
-                                    "No se encontraron productos",
+                                    stringResource(R.string.product_list_no_products),
                                     style = MaterialTheme.typography.titleLarge,
                                     color = MaterialTheme.colorScheme.tertiary
                                 )

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/FiltersMenu.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/FiltersMenu.kt
@@ -16,7 +16,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.amrubio27.cursotestingandroid.R
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.FILTER_VIEW
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.productListCategory
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.productListSortOption
@@ -43,7 +45,7 @@ fun FiltersMenu(
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             Text(
-                "Categorías",
+                stringResource(R.string.product_list_sort_title_categories),
                 style = MaterialTheme.typography.titleSmall,
                 color = MaterialTheme.colorScheme.onSurface
             )
@@ -57,7 +59,12 @@ fun FiltersMenu(
                     modifier = Modifier.testTag(productListCategory(null)),
                     selected = state.selectedCategory == null,
                     onClick = { onCategorySelected(null) },
-                    label = { Text("Todas", style = MaterialTheme.typography.labelSmall) }
+                    label = {
+                        Text(
+                            stringResource(R.string.product_list_category_all),
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                    }
                 )
                 state.categories.forEach { category ->
                     FilterChip(
@@ -72,7 +79,7 @@ fun FiltersMenu(
             HorizontalDivider()
 
             Text(
-                "Ordenar por",
+                stringResource(R.string.product_list_sort_title),
                 style = MaterialTheme.typography.titleSmall,
                 color = MaterialTheme.colorScheme.onSurface
             )
@@ -85,7 +92,12 @@ fun FiltersMenu(
                 FilterChip(
                     selected = state.sortOption == SortOption.PRICE_ASC,
                     onClick = { onSortSelected(SortOption.PRICE_ASC) },
-                    label = { Text("Precio ↑", style = MaterialTheme.typography.labelSmall) },
+                    label = {
+                        Text(
+                            stringResource(R.string.product_list_sort_price_asc),
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                    },
                     modifier = Modifier
                         .weight(1f)
                         .testTag(productListSortOption(SortOption.PRICE_ASC))
@@ -93,7 +105,12 @@ fun FiltersMenu(
                 FilterChip(
                     selected = state.sortOption == SortOption.PRICE_DESC,
                     onClick = { onSortSelected(SortOption.PRICE_DESC) },
-                    label = { Text("Precio ↓", style = MaterialTheme.typography.labelSmall) },
+                    label = {
+                        Text(
+                            stringResource(R.string.product_list_sort_price_desc),
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                    },
                     modifier = Modifier
                         .weight(1f)
                         .testTag(productListSortOption(SortOption.PRICE_DESC))
@@ -101,7 +118,12 @@ fun FiltersMenu(
                 FilterChip(
                     selected = state.sortOption == SortOption.DISCOUNT,
                     onClick = { onSortSelected(SortOption.DISCOUNT) },
-                    label = { Text("Descuento", style = MaterialTheme.typography.labelSmall) },
+                    label = {
+                        Text(
+                            stringResource(R.string.product_list_sort_discount),
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                    },
                     modifier = Modifier
                         .weight(1f)
                         .testTag(productListSortOption(SortOption.DISCOUNT))

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/HomeTopAppBar.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/HomeTopAppBar.kt
@@ -17,8 +17,10 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.unit.dp
+import com.amrubio27.cursotestingandroid.R
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.TOP_APP_BAR_BADGE
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.TOP_APP_BAR_CART
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.TOP_APP_BAR_FILTER
@@ -37,7 +39,7 @@ fun HomeTopAppBar(
     TopAppBar(
         title = {
             Text(
-                "MiniMarket",
+                stringResource(R.string.product_list_app_title),
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = Bold
             )
@@ -53,7 +55,9 @@ fun HomeTopAppBar(
             ) {
                 Icon(
                     imageVector = Icons.Default.FilterList,
-                    contentDescription = if (filtersVisible) "Ocultar filtros" else "Mostrar filtros",
+                    contentDescription = if (filtersVisible) stringResource(R.string.product_list_hide_filters) else stringResource(
+                        R.string.product_list_show_filters
+                    ),
                     tint = MaterialTheme.colorScheme.onPrimaryContainer
                 )
             }

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/ProductItem.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/components/ProductItem.kt
@@ -23,11 +23,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.amrubio27.cursotestingandroid.R
 import com.amrubio27.cursotestingandroid.core.presentation.testing.UiTestTag.productListItem
 import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductPromotion
 import com.amrubio27.cursotestingandroid.productlist.domain.model.ProductWithPromotion
@@ -140,7 +142,7 @@ fun ProductItem(
                                 horizontalArrangement = Arrangement.spacedBy(8.dp)
                             ) {
                                 Text(
-                                    "Antes",
+                                    stringResource(R.string.product_list_price_before),
                                     style = MaterialTheme.typography.labelSmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
@@ -156,7 +158,7 @@ fun ProductItem(
                                 horizontalArrangement = Arrangement.spacedBy(8.dp)
                             ) {
                                 Text(
-                                    "Ahora",
+                                    stringResource(R.string.product_list_price_now),
                                     style = MaterialTheme.typography.labelSmall,
                                     color = MaterialTheme.colorScheme.primary
                                 )

--- a/app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreen.kt
+++ b/app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreen.kt
@@ -124,7 +124,7 @@ fun SettingsContent(
                                 fontWeight = FontWeight.Medium
                             )
                             Text(
-                                "Muestra únicamente productos disponibles",
+                                stringResource(R.string.settings_in_stock_only_desc),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
@@ -148,12 +148,12 @@ fun SettingsContent(
                             verticalArrangement = Arrangement.spacedBy(4.dp)
                         ) {
                             Text(
-                                "Mostrar impuestos incluídos",
+                                stringResource(R.string.settings_show_taxes),
                                 style = MaterialTheme.typography.bodyLarge,
                                 fontWeight = FontWeight.Medium
                             )
                             Text(
-                                "Incluir impuestos de los precios mostrados",
+                                stringResource(R.string.settings_show_taxes_desc),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
@@ -189,7 +189,7 @@ fun SettingsContent(
                         )
 
                         Text(
-                            "Apariencia",
+                            stringResource(R.string.settings_appearance_section),
                             style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.onSurface,
                             fontWeight = FontWeight.Bold
@@ -208,7 +208,7 @@ fun SettingsContent(
                             fontWeight = FontWeight.Medium
                         )
                         Text(
-                            "Elige entre modo claro, oscuro o seguir el sistema",
+                            stringResource(R.string.settings_theme_desc),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
@@ -221,21 +221,21 @@ fun SettingsContent(
                                 shape = SegmentedButtonDefaults.itemShape(0, 3),
                                 onClick = { onThemeModeSelected(ThemeMode.SYSTEM) },
                                 selected = uiState.themeMode == ThemeMode.SYSTEM,
-                                label = { Text("Sistema") }
+                                label = { Text(stringResource(R.string.settings_theme_system)) }
                             )
                             SegmentedButton(
                                 modifier = Modifier.testTag(UiTestTag.settingsThemeOption("light")),
                                 shape = SegmentedButtonDefaults.itemShape(1, 3),
                                 onClick = { onThemeModeSelected(ThemeMode.LIGHT) },
                                 selected = uiState.themeMode == ThemeMode.LIGHT,
-                                label = { Text("Claro") }
+                                label = { Text(stringResource(R.string.settings_theme_light)) }
                             )
                             SegmentedButton(
                                 modifier = Modifier.testTag(UiTestTag.settingsThemeOption("dark")),
                                 shape = SegmentedButtonDefaults.itemShape(2, 3),
                                 onClick = { onThemeModeSelected(ThemeMode.DARK) },
                                 selected = uiState.themeMode == ThemeMode.DARK,
-                                label = { Text("Oscuro") }
+                                label = { Text(stringResource(R.string.settings_theme_dark)) }
                             )
                         }
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,11 +1,63 @@
 <resources>
     <string name="app_name">CursoTestingAndroid</string>
 
+    <!-- General -->
+    <string name="back_button_content_desc">Atrás</string>
+    <string name="error_title">ERROR</string>
+
     <!-- Settings -->
     <string name="settings_title">Ajustes</string>
     <string name="settings_filters_section">Filtros y visualización</string>
     <string name="settings_in_stock_only">Solo productos en Stock</string>
+    <string name="settings_in_stock_only_desc">Muestra únicamente productos disponibles</string>
+    <string name="settings_show_taxes">Mostrar impuestos incluídos</string>
+    <string name="settings_show_taxes_desc">Incluir impuestos de los precios mostrados</string>
     <string name="settings_appearance_section">Apariencia</string>
     <string name="settings_theme_label">Tema de la aplicación</string>
+    <string name="settings_theme_desc">Elige entre modo claro, oscuro o seguir el sistema</string>
+    <string name="settings_theme_system">Sistema</string>
+    <string name="settings_theme_light">Claro</string>
+    <string name="settings_theme_dark">Oscuro</string>
+
+    <!-- Product List -->
+    <string name="product_list_count">%1$d productos</string>
+    <string name="product_list_no_products">No se encontraron productos</string>
+    <string name="product_list_category_all">Todas</string>
+    <string name="product_list_sort_title_categories">Categorías</string>
+    <string name="product_list_sort_title">Ordenar por</string>
+    <string name="product_list_sort_price_asc">Precio ↑</string>
+    <string name="product_list_sort_price_desc">Precio ↓</string>
+    <string name="product_list_sort_discount">Descuento</string>
+    <string name="product_list_app_title">MiniMarket</string>
+    <string name="product_list_hide_filters">Ocultar filtros</string>
+    <string name="product_list_show_filters">Mostrar filtros</string>
+    <string name="product_list_price_before">Antes</string>
+    <string name="product_list_price_now">Ahora</string>
+
+    <!-- Product Detail -->
+    <string name="detail_no_stock_available">Sin stock disponible</string>
+    <string name="detail_error_insufficient_stock">No hay suficiente stock</string>
+    <string name="detail_error_network">No hay internet, compruebe su conexión</string>
+    <string name="detail_error_unknown">Error inesperado, vuelva a intentarlo</string>
+    <string name="detail_success_added">Producto añadido</string>
+    <string name="detail_percent_off">%1$d%% OFF</string>
+    <string name="detail_promo">PROMO: %1$s</string>
+    <string name="detail_stock_available">Stock disponible</string>
+    <string name="detail_stock_units">%1$d unidades</string>
+    <string name="detail_no_stock">Sin stock</string>
+    <string name="detail_add_to_cart">Agregar al carrito</string>
+
+    <!-- Cart -->
+    <string name="cart_title">Carrito</string>
+    <string name="cart_error_message">Error: %1$s</string>
+    <string name="cart_retry_button">Reintentar</string>
+    <string name="cart_empty_title">Tu carrito está vacío</string>
+    <string name="cart_empty_subtitle">Agrega productos para comenzar</string>
+    <string name="cart_summary_title">Resumen del carrito</string>
+    <string name="cart_subtotal_label">Subtotal:</string>
+    <string name="cart_discount_label">Descuento:</string>
+    <string name="cart_total_label">Total:</string>
+    <string name="cart_price_per_unit">%1$s c/u</string>
+    <string name="cart_item_total">Total: %1$s</string>
 
 </resources>


### PR DESCRIPTION
# Guía y Documentación de Cambios: Internacionalización y Buenas Prácticas en Jetpack Compose

Esta Pull Request contiene la migración integral de las cadenas de texto del proyecto al sistema de recursos oficial de Android (`strings.xml`) y la adecuación de los tests instrumentados. A continuación, se detallan los conceptos didácticos y los patrones recomendados aplicados en la refactorización para futuras referencias.

---

## 📖 Concepto 1: Evitar Strings Hardcodeados (Internacionalización)

### ¿Por qué?
* **Localización (i18n):** Tener cadenas literales en el código fuente (como `"Agregar al carrito"`) impide traducir la aplicación a múltiples idiomas de forma nativa.
* **Separación de Conceptos:** El código lógico de las vistas no debe preocuparse del contenido de texto específico.
* **Mantenibilidad:** Cambiar un mensaje en la aplicación se reduce a editar un único archivo de configuración (`strings.xml`) en lugar de buscar por toda la base de código.

### Estructura de Recursos (`strings.xml`)
Se ha configurado una organización jerárquica mediante prefijos claros para evitar colisiones de nombres:
```xml
<!-- Detalle de Producto -->
<string name="detail_stock_units">%1$d unidades</string>
<string name="detail_no_stock">Sin stock</string>
<string name="detail_add_to_cart">Agregar al carrito</string>
<string name="detail_percent_off">%1$d%% OFF</string>
```
* **Nota didáctica sobre parámetros posicionales (`%1$d`, `%1$s`):** Permiten la interpolación dinámica de variables dentro de los textos. El orden de las palabras puede variar según el idioma (por ejemplo, en inglés "5 units" y en español "5 unidades"), por lo que indicar la posición `%1` garantiza que la variable se inserte en el lugar sintáctico correcto de cada idioma.

---

## 📖 Concepto 2: El error `LocalContextGetResourceValueCall` de Compose

### ¿Por qué ocurre?
El compilador y el runtime de Jetpack Compose rastrean la lectura de estados composables para decidir cuándo repintar (*recomponer*) la interfaz. 
El uso de `LocalContext.current` para resolver recursos de la siguiente manera:
```kotlin
// ❌ Código incorrecto e ineficiente (Provoca advertencia de Lint)
LaunchedEffect(key1 = true) {
    productDetailViewModel.events.collect { event ->
        if (event == ProductDetailEvent.SUCCESS_ADD_TO_CART) {
            // El Contexto obtenido no reacciona a cambios de configuración
            snackbarHostState.showSnackbar(context.getString(R.string.detail_success_added))
        }
    }
}
```
**El problema:** Si el usuario realiza un cambio de configuración del dispositivo (como rotar la pantalla, cambiar el idioma en los ajustes del sistema o alternar a Modo Oscuro) mientras la corrutina está activa, el `Context` no provoca una recomposición en este punto. Como resultado, la UI mostrará textos antiguos u obsoletos (*stale values*).

### La solución moderna (Recomposición Reactiva)
Debemos extraer la resolución del recurso al flujo composable usando la API nativa `stringResource(...)`. Compose sí rastrea esta función y provocará una recomposición instantánea ante cualquier cambio de configuración.

```kotlin
//  Código correcto y moderno
@Composable
fun ProductDetailScreen(...) {
    // 1. Resolvemos el recurso de forma segura y reactiva en el top-level del Composable
    val successAddedMessage = stringResource(R.string.detail_success_added)
    
    // ...
    
    LaunchedEffect(key1 = true) {
        productDetailViewModel.events.collect { event ->
            if (event == ProductDetailEvent.SUCCESS_ADD_TO_CART) {
                // 2. Usamos la variable precargada dentro del bloque suspendido
                snackbarHostState.showSnackbar(successAddedMessage)
            }
        }
    }
}
```

---

## 📖 Concepto 3: Tests UI Dinámicos y Robustos (`androidTest`)

### ¿Por qué?
Si tus tests de interfaz de usuario buscan textos exactos hardcodeados:
```kotlin
// ❌ Test frágil y propenso a fallos
composeRule.onNodeWithText("Sin stock").assertIsDisplayed()
```
Cualquier cambio de redacción en `strings.xml` (por ejemplo, cambiar "Sin stock" a "No disponible") romperá tus tests a pesar de que la lógica de la app sigue siendo correcta.

### La solución moderna: Lectura dinámica desde recursos
Se implementa una función de utilidad `getString(...)` en las clases de test. Esta función utiliza el contexto de la actividad bajo prueba para resolver el identificador de recurso en tiempo de ejecución:

```kotlin
class ProductDetailScreenTest {

    @get:Rule
    val composeRule = createAndroidComposeRule<ComponentActivity>()

    // Utilidad didáctica para resolver recursos de string con y sin argumentos
    private fun getString(resId: Int): String = composeRule.activity.getString(resId)
    private fun getString(resId: Int, vararg formatArgs: Any): String = 
        composeRule.activity.getString(resId, *formatArgs)

    @Test
    fun givenSuccessStateNoStock_whenRendered_thenShowsNoStockAndAddToCartButtonDisabled() {
        createProductDetailScreen(uiState = ProductDetailUiStateMother.success(stock = 0))

        //  Test robusto: lee del strings.xml dinámicamente
        composeRule.onNodeWithText(getString(R.string.detail_no_stock)).assertIsDisplayed()
    }
}
```

---

## 🗂️ Archivos Clave Modificados

| Fichero | Propósito |
| :--- | :--- |
| [strings.xml](file:///d:/Programacion/cursoTestingAndroid/app/src/main/res/values/strings.xml) | Definición centralizada de strings parametrizados del sistema de recursos de Android. |
| [ProductDetailScreen.kt](file:///d:/Programacion/cursoTestingAndroid/app/src/main/java/com/amrubio27/cursotestingandroid/detail/presentation/ProductDetailScreen.kt) | Corrección del Lint `LocalContext` y extracción de strings promocionales y de stock. |
| [CartScreen.kt](file:///d:/Programacion/cursoTestingAndroid/app/src/main/java/com/amrubio27/cursotestingandroid/cart/presentation/CartScreen.kt) | Extracción de strings del resumen del carrito, precios unitarios y estados vacíos. |
| [SettingsScreen.kt](file:///d:/Programacion/cursoTestingAndroid/app/src/main/java/com/amrubio27/cursotestingandroid/settings/presentation/SettingsScreen.kt) | Migración de los textos de apariencia, switch de impuestos y tema seleccionado. |
| [ProductListScreen.kt](file:///d:/Programacion/cursoTestingAndroid/app/src/main/java/com/amrubio27/cursotestingandroid/productlist/presentation/ProductListScreen.kt) | Extracción de contadores de productos y strings de filtros/ordenamiento. |
| `*ScreenTest.kt` | Actualización de tests para usar la aserción con `getString(resId)`. |

---

## 🛠️ Cómo Validar los Cambios en Android Studio

1. **Compilación Limpia:** Ejecuta `./gradlew clean build` para verificar que todas las referencias `R.string` se autogeneran y compilan correctamente.
2. **Ejecución de Tests Unitarios:**
   - Abre la pestaña **Run** y ejecuta los tests en `app/src/test/java`.
3. **Ejecución de Tests de UI:**
   - Conecta un emulador y haz click derecho sobre la carpeta `androidTest/java` -> Selecciona **Run 'All Tests'**. Todos los tests instrumentados de interfaz de usuario deben pasar al 100% de manera exitosa usando los textos dinámicos de recursos.
